### PR TITLE
Display date on job listing

### DIFF
--- a/src/components/jobs/JobListing.vue
+++ b/src/components/jobs/JobListing.vue
@@ -9,7 +9,7 @@
             <div class="salary-info">
               <b-badge v-if="job.salary_min > 0" class="salary-badge">{{ salary }}</b-badge>
             </div>
-            <p class="subtitle">Posted at </p>
+            <p class="subtitle">Posted {{ formattedDate }}</p>
 
 
             <!-- Render the description with markup support -->
@@ -51,6 +51,17 @@ export default defineComponent({
     }
   },
   computed: {
+    formattedDate() {
+      const job = this.job
+      if (job.created != null) {
+        const date = new Date(job.created)
+        return new Intl.DateTimeFormat('en-US', {
+          dateStyle: "medium"
+        }).format(date)
+      } else {
+        return ''
+      }
+    },
     salary() {
       const j = this.job
       if (j.salary_max != null && j.salary_min != null) {


### PR DESCRIPTION
## Summary
Closes #19. When viewing a job listing, the posted date will now be visible. Previously, it said "Posted at" with no date shown.

## Context
This provides users with better context on how long a listing has been active. Older listings may be stale (since we display them for 60 days), while newer ones may encourage early applications.

## Details
- Updated `JobListing.vue`
- Adjusted template copy (removed "at")
- Added a new computed property, `formattedDate()`, which uses `Intl.DateTimeFormat` to format the `job.created` timestamp
- The `job.created` value is in UTC, but we display it in the user's local time (date only)

## Screenshot
<img width="1440" height="754" alt="Screen Shot 2025-07-31 at 8 28 45 PM" src="https://github.com/user-attachments/assets/21816eec-d54e-41e8-a2a3-c2cb88899d55" />