### PR TITLE
Hide "How to apply" section for existing jobs

### DIFF
--- a/src/components/jobs/JobListing.vue
+++ b/src/components/jobs/JobListing.vue
@@ -13,7 +13,7 @@
 
             <!-- Render the description and how to apply with markup support -->
             <div class="job-description" v-html="sanitizedDescription"></div>
-            <div class="how-to-apply">
+            <div class="how-to-apply" v-if="job.how_to_apply">
               <p class="how-to-apply-title">How to apply:</p>
               <div class="job-how-to-apply" v-html="sanitizedHowToApply"></div>
             </div>


### PR DESCRIPTION
## Description
Closes #26 

## Details
- Updated `JobListing.vue` template to only show "How to apply" section when `job.how_to_apply` is present
- Tested by creating job records before `017_updated_jobs_for_automated_job_creation.js` migration (before `how_to_apply` field was required), then applying the migration, and finally testing correct display for existing jobs and new jobs.

