### PR TITLE
Add approved_at timestamp and tweaks the atom feed

### DIFF
--- a/pb/hooks/atom.pb.js
+++ b/pb/hooks/atom.pb.js
@@ -6,13 +6,15 @@ routerAdd("get", "/jobs_test.atom", (e) => {
   );
 
 
+  const cutoff = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString()
+
   let records = $app.findRecordsByFilter(
     "jobs",                                    // collection
-    "", // filter
-    "-created",                                   // sort
-    20,                                            // limit
-    0,                                             // offset
-    { },                        // optional filter params
+    'approved = true && approved_at != "" && approved_at >= {:cutoff}', // filter
+    "-approved_at",                            // sort
+    20,                                        // limit
+    0,                                         // offset
+    { cutoff },                                // filter params
   )
 
   const entries = records.map((r) => ({
@@ -20,7 +22,7 @@ routerAdd("get", "/jobs_test.atom", (e) => {
     author:  r.getString("company"),
     link:    `https://indyhackers.org/posts/${r.id}`,
     id:      `tag:indyhackers.org,2025:post/${r.id}`,
-    updated: new Date(r.getDateTime("created")).toISOString(),
+    updated: new Date(r.getDateTime("approved_at")).toISOString(),
     summary: r.getString("description") || "",
   }));
 

--- a/pb/hooks/jobs.pb.js
+++ b/pb/hooks/jobs.pb.js
@@ -6,3 +6,18 @@ onRecordEnrich((e) => {
 
     e.next()
 }, "jobs")
+
+onRecordUpdate((e) => {
+    const wasApproved = e.record.original().getBool("approved")
+    const isApproved = e.record.getBool("approved")
+
+    if (!wasApproved && isApproved) {
+        // approved just flipped to true — stamp the time
+        e.record.set("approved_at", new Date().toISOString())
+    } else if (wasApproved && !isApproved) {
+        // approved flipped back to false — clear the timestamp
+        e.record.set("approved_at", "")
+    }
+
+    e.next()
+}, "jobs")

--- a/pb/migrations/018_add_approved_at_to_jobs.js
+++ b/pb/migrations/018_add_approved_at_to_jobs.js
@@ -1,0 +1,29 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_2409499253")
+
+  // add approved_at date field
+  collection.fields.addAt(8, new Field({
+    "hidden": false,
+    "id": "date_approved_at",
+    "name": "approved_at",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "date"
+  }))
+
+  app.save(collection)
+
+  // backfill: set approved_at = created for existing approved jobs
+  app.db().newQuery(
+    "UPDATE jobs SET approved_at = created WHERE approved = true AND (approved_at IS NULL OR approved_at = '')"
+  ).execute()
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_2409499253")
+
+  // remove approved_at field
+  collection.fields.removeById("date_approved_at")
+
+  return app.save(collection)
+})

--- a/src/components/__tests__/JobListing.spec.js
+++ b/src/components/__tests__/JobListing.spec.js
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import JobListing from '../jobs/JobListing.vue'
+
+const mockJob = {
+  id: 'job1',
+  title: 'Senior Developer',
+  company: 'Acme Corp',
+  salary_min: 100,
+  salary_max: 150,
+  description: '<p>Great <strong>opportunity</strong></p>',
+  how_to_apply: '<p>Email <a href="mailto:hr@acme.com">hr@acme.com</a></p>',
+  created: '2025-01-10T12:00:00.000Z',
+  approved_at: '2025-01-15T12:00:00.000Z',
+  approved: true,
+}
+
+function createMockPocketBase(job = mockJob) {
+  return {
+    collection: vi.fn().mockReturnValue({
+      getOne: vi.fn().mockResolvedValue(job),
+    }),
+  }
+}
+
+function mountJobListing(pb, routeQuery = { id: 'job1' }) {
+  return mount(JobListing, {
+    global: {
+      config: {
+        globalProperties: {
+          pocketbase: pb,
+          $route: { query: routeQuery },
+        },
+      },
+      stubs: {
+        'b-container': { template: '<div><slot /></div>' },
+        'b-row': { template: '<div><slot /></div>' },
+        'b-col': { template: '<div><slot /></div>' },
+        'b-card': { template: '<div class="b-card"><slot /></div>' },
+        'b-badge': { template: '<span class="b-badge"><slot /></span>' },
+      },
+    },
+  })
+}
+
+describe('JobListing', () => {
+  let pb
+
+  beforeEach(() => {
+    pb = createMockPocketBase()
+  })
+
+  it('fetches the job by ID from route query', async () => {
+    mountJobListing(pb)
+    await flushPromises()
+
+    expect(pb.collection).toHaveBeenCalledWith('jobs')
+    expect(pb.collection.mock.results[0].value.getOne).toHaveBeenCalledWith('job1')
+  })
+
+  it('displays the job title and company', async () => {
+    const wrapper = mountJobListing(pb)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Senior Developer')
+    expect(wrapper.text()).toContain('Acme Corp')
+  })
+
+  it('displays "Posted" date formatted from job.approved_at', async () => {
+    const wrapper = mountJobListing(pb)
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Posted Jan 15, 2025')
+  })
+
+  it('displays salary badge with min-max format', async () => {
+    const wrapper = mountJobListing(pb)
+    await flushPromises()
+
+    expect(wrapper.find('.b-badge').text()).toBe('$100-150K')
+  })
+
+  it('displays salary as $minK (min) when only min is set', async () => {
+    const job = { ...mockJob, salary_max: 0 }
+    const localPb = createMockPocketBase(job)
+    const wrapper = mountJobListing(localPb)
+    await flushPromises()
+
+    expect(wrapper.find('.b-badge').text()).toBe('$100K (min)')
+  })
+
+  it('displays salary as $maxK (max) when only max is set', async () => {
+    const job = { ...mockJob, salary_min: 0 }
+    const localPb = createMockPocketBase(job)
+    const wrapper = mountJobListing(localPb)
+    await flushPromises()
+
+    expect(wrapper.find('.b-badge').text()).toBe('$150K (max)')
+  })
+
+  it('sanitizes HTML in description', async () => {
+    const job = {
+      ...mockJob,
+      description: '<p>Hello</p><script>alert("xss")</script>',
+    }
+    const localPb = createMockPocketBase(job)
+    const wrapper = mountJobListing(localPb)
+    await flushPromises()
+
+    const descDiv = wrapper.find('.job-description')
+    expect(descDiv.html()).toContain('<p>Hello</p>')
+    expect(descDiv.html()).not.toContain('<script>')
+  })
+
+  it('sanitizes HTML in how_to_apply', async () => {
+    const job = {
+      ...mockJob,
+      how_to_apply: '<p>Apply</p><img src=x onerror=alert(1)>',
+    }
+    const localPb = createMockPocketBase(job)
+    const wrapper = mountJobListing(localPb)
+    await flushPromises()
+
+    const applyDiv = wrapper.find('.job-how-to-apply')
+    expect(applyDiv.html()).toContain('<p>Apply</p>')
+    expect(applyDiv.html()).not.toContain('onerror')
+  })
+
+  it('renders how_to_apply section only when present', async () => {
+    const job = { ...mockJob, how_to_apply: '' }
+    const localPb = createMockPocketBase(job)
+    const wrapper = mountJobListing(localPb)
+    await flushPromises()
+
+    expect(wrapper.find('.how-to-apply').exists()).toBe(false)
+  })
+
+  it('does not fetch when no job ID is in route query', async () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    mountJobListing(pb, {})
+    await flushPromises()
+
+    expect(pb.collection).not.toHaveBeenCalled()
+    expect(consoleSpy).toHaveBeenCalledWith('No jobId provided in query parameters.')
+    consoleSpy.mockRestore()
+  })
+})

--- a/src/components/__tests__/JobsList.spec.js
+++ b/src/components/__tests__/JobsList.spec.js
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import JobsList from '../jobs/JobsList.vue'
+
+const mockJobs = [
+  {
+    id: 'job1',
+    title: 'Senior Developer',
+    company: 'Acme Corp',
+    salary_min: 100,
+    salary_max: 150,
+    approved: true,
+    created: '2025-01-15T12:00:00.000Z',
+  },
+  {
+    id: 'job2',
+    title: 'Designer',
+    company: 'Design Co',
+    salary_min: 80,
+    salary_max: 0,
+    approved: true,
+    created: '2025-01-10T12:00:00.000Z',
+  },
+  {
+    id: 'job3',
+    title: 'Intern',
+    company: 'Startup Inc',
+    salary_min: 0,
+    salary_max: 40,
+    approved: true,
+    created: '2025-01-05T12:00:00.000Z',
+  },
+  {
+    id: 'job4',
+    title: 'Volunteer',
+    company: 'Nonprofit',
+    salary_min: 0,
+    salary_max: 0,
+    approved: true,
+    created: '2025-01-01T12:00:00.000Z',
+  },
+]
+
+function createMockPocketBase(jobs = mockJobs) {
+  return {
+    collection: vi.fn().mockReturnValue({
+      getList: vi.fn().mockResolvedValue({ items: jobs }),
+    }),
+  }
+}
+
+function createMockRouter() {
+  return {
+    push: vi.fn(),
+  }
+}
+
+function mountJobsList(pb, router) {
+  return mount(JobsList, {
+    global: {
+      config: {
+        globalProperties: {
+          pocketbase: pb,
+          $router: router,
+        },
+      },
+      stubs: {
+        'b-container': { template: '<div><slot /></div>' },
+        'b-row': { template: '<div><slot /></div>' },
+        'b-col': { template: '<div><slot /></div>' },
+        'b-card': {
+          template: '<div class="b-card" @click="$emit(\'click\')"><slot /></div>',
+          props: ['title'],
+        },
+        'b-badge': { template: '<span class="b-badge"><slot /></span>' },
+        'create-job-modal': { template: '<div />' },
+      },
+    },
+  })
+}
+
+describe('JobsList', () => {
+  let pb, router
+
+  beforeEach(() => {
+    pb = createMockPocketBase()
+    router = createMockRouter()
+  })
+
+  it('fetches approved jobs within 60-day window sorted by -approved_at', async () => {
+    mountJobsList(pb, router)
+    await flushPromises()
+
+    const collection = pb.collection
+    expect(collection).toHaveBeenCalledWith('jobs')
+
+    const getList = collection.mock.results[0].value.getList
+    const callArgs = getList.mock.calls[0]
+    expect(callArgs[0]).toBe(1)
+    expect(callArgs[1]).toBe(100)
+    expect(callArgs[2].sort).toBe('-approved_at')
+    expect(callArgs[2].filter).toBe(
+      'approved = true && approved_at != "" && approved_at >= {:cutoff}',
+    )
+    expect(callArgs[2].filterParams).toBeDefined()
+    // cutoff should be roughly 60 days ago
+    const cutoff = new Date(callArgs[2].filterParams.cutoff)
+    const sixtyDaysAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000)
+    expect(Math.abs(cutoff - sixtyDaysAgo)).toBeLessThan(5000)
+  })
+
+  it('renders a card for each job with title and company', async () => {
+    const wrapper = mountJobsList(pb, router)
+    await flushPromises()
+
+    const cards = wrapper.findAll('.b-card')
+    expect(cards).toHaveLength(4)
+
+    expect(cards[0].text()).toContain('Acme Corp')
+    expect(cards[1].text()).toContain('Design Co')
+  })
+
+  it('displays salary as $min-maxK when both are set', async () => {
+    const wrapper = mountJobsList(pb, router)
+    await flushPromises()
+
+    const badges = wrapper.findAll('.b-badge')
+    expect(badges[0].text()).toBe('$100-150K')
+  })
+
+  it('displays salary as $minK (min) when only min is set', async () => {
+    const wrapper = mountJobsList(pb, router)
+    await flushPromises()
+
+    const badges = wrapper.findAll('.b-badge')
+    expect(badges[1].text()).toBe('$80K (min)')
+  })
+
+  it('displays salary as $maxK (max) when only max is set', async () => {
+    const wrapper = mountJobsList(pb, router)
+    await flushPromises()
+
+    const badges = wrapper.findAll('.b-badge')
+    expect(badges[2].text()).toBe('$40K (max)')
+  })
+
+  it('hides salary badge when both min and max are 0', async () => {
+    const wrapper = mountJobsList(pb, router)
+    await flushPromises()
+
+    // The 4th job has salary_min=0 and salary_max=0, so salary() returns null
+    // The badge renders but with empty content
+    const badges = wrapper.findAll('.b-badge')
+    expect(badges[3].text()).toBe('')
+  })
+
+  it('navigates to /job?id=<id> when a card is clicked', async () => {
+    const wrapper = mountJobsList(pb, router)
+    await flushPromises()
+
+    const cards = wrapper.findAll('.b-card')
+    await cards[0].trigger('click')
+
+    expect(router.push).toHaveBeenCalledWith({ path: '/job', query: { id: 'job1' } })
+  })
+})

--- a/src/components/jobs/JobListing.vue
+++ b/src/components/jobs/JobListing.vue
@@ -59,8 +59,8 @@ export default defineComponent({
   computed: {
     formattedDate() {
       const job = this.job
-      if (job.created != null) {
-        const date = new Date(job.created)
+      if (job.approved_at != null && job.approved_at !== '') {
+        const date = new Date(job.approved_at)
         return new Intl.DateTimeFormat('en-US', {
           dateStyle: "medium"
         }).format(date)

--- a/src/components/jobs/JobsList.vue
+++ b/src/components/jobs/JobsList.vue
@@ -43,10 +43,12 @@ export default defineComponent({
   methods: {
     async fetchJobs() {
       try {
+        const cutoff = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString()
         const jobs = await this.pocketbase.collection('jobs').getList(
           1, 100,{
-            sort: '-created',
-            filter: 'approved = true'
+            sort: '-approved_at',
+            filter: 'approved = true && approved_at != "" && approved_at >= {:cutoff}',
+            filterParams: { cutoff }
         })
         this.jobs = jobs.items
       } catch (error) {

--- a/src/mocks/mocks.json
+++ b/src/mocks/mocks.json
@@ -114,6 +114,7 @@
     "items": [
       {
         "approved": true,
+        "approved_at": "2024-09-18 16:00:00.000Z",
         "collectionId": "5o7y83cyhnt62fa",
         "collectionName": "jobs",
         "company": " Knowledge Services",
@@ -128,6 +129,7 @@
       },
       {
         "approved": true,
+        "approved_at": "2024-09-18 16:17:00.000Z",
         "collectionId": "5o7y83cyhnt62fa",
         "collectionName": "jobs",
         "company": "Theoris",
@@ -142,6 +144,7 @@
       },
       {
         "approved": true,
+        "approved_at": "2024-09-18 16:17:00.000Z",
         "collectionId": "5o7y83cyhnt62fa",
         "collectionName": "jobs",
         "company": "SEP",
@@ -156,6 +159,7 @@
       },
       {
         "approved": false,
+        "approved_at": "",
         "collectionId": "5o7y83cyhnt62fa",
         "collectionName": "jobs",
         "company": "Bunk Company",


### PR DESCRIPTION
This PR introduces the following changes:
- tests to pin the job listing & list view logic in-place before adding new `approved_at` field to jobs
- adds a new column, `approved_at` for job listings
- backfill for old job listings. `approved_at` will equal the created date
- a hook to set `approved_at` when a job listing goes from no approval to approved
  - this also sets it to an empty string if a job goes the other direction
- update jobs view to query for approved jobs that were approved in the last 60 days
- adds a filter to atom view to only show approved listings from the last 60 days