### PR TITLE
add Donate button to all pages

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -28,6 +28,17 @@ export default {
       return this.pocketbase.authStore.model
     }
   },
+  mounted() {
+    // Givebutter floating donate widget
+    const widget = document.createElement('givebutter-widget')
+    widget.setAttribute('id', 'pdVAqB')
+    document.body.appendChild(widget)
+
+    const script = document.createElement('script')
+    script.src = 'https://widgets.givebutter.com/latest.umd.cjs?acct=H4rBBvimtKt1fpCm&p=other'
+    script.async = true
+    document.head.appendChild(script)
+  },
 }
 </script>
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,7 +12,13 @@ import { VitePluginRadar } from 'vite-plugin-radar'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
-    vue(),
+    vue({
+      template: {
+        compilerOptions: {
+          isCustomElement: (tag) => tag.startsWith('givebutter-')
+        }
+      }
+    }),
     vueDevTools(),
     Components({
       resolvers: [BootstrapVueNextResolver(), IconsResolve()]


### PR DESCRIPTION
This PR introduces the following changes:
- sets up the Givebutter integration
  - see [this doc](https://docs.givebutter.com/widgets/getting-started#embedding-widgets) for installation details
- adds the Donate button to float on all pages

Here's what it looks like:
<img width="1400" height="796" alt="image" src="https://github.com/user-attachments/assets/115e1120-bf23-4dec-8c57-d491060cd0e1" />
