### PR TITLE
Upgrade PocketBase to 0.39.4 + JS SDK to 0.27.0

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
       args:
         TARGETOS: linux
         TARGETARCH: ${TARGETARCH:-amd64}
-        PB_VERSION: 0.28.4
+        PB_VERSION: 0.39.4
         PB_ENV: development
     container_name: pocketbase
     environment:

--- a/docker-compose_production.yaml
+++ b/docker-compose_production.yaml
@@ -6,7 +6,7 @@ services:
       args:
         TARGETOS: linux
         TARGETARCH: ${TARGETARCH:-amd64}
-        PB_VERSION: 0.28.4
+        PB_VERSION: 0.39.4
         PB_ENV: production
     container_name: indyhackers
     environment:

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "dompurify": "^3.3.2",
         "jquery": "^3.7.1",
         "pinia": "^2.1.7",
-        "pocketbase": "^0.26.1",
+        "pocketbase": "^0.27.0",
         "shards-ui": "^1.1.2",
         "tiny-emitter": "2.0.2",
         "vite-plugin-radar": "^0.10.0",
@@ -5653,9 +5653,9 @@
       }
     },
     "node_modules/pocketbase": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/pocketbase/-/pocketbase-0.26.1.tgz",
-      "integrity": "sha512-fjcPDpxyqTZCwqGUTPUV7vssIsNMqHxk9GxbhxYHPEf18RqX2d9cpSqbbHk7aas30jqkgptuKfG7aY/Mytjj3g==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/pocketbase/-/pocketbase-0.27.0.tgz",
+      "integrity": "sha512-K5N6d93UP/BNMbMnlZ6BUfy9VPCIvLyqhJFOsNI8OsZwzvKWEAfyD36boi5K4ECIOl5HMlo0TzuaeGdKpMwizQ==",
       "license": "MIT"
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dompurify": "^3.3.2",
     "jquery": "^3.7.1",
     "pinia": "^2.1.7",
-    "pocketbase": "^0.26.1",
+    "pocketbase": "^0.27.0",
     "shards-ui": "^1.1.2",
     "tiny-emitter": "2.0.2",
     "vite-plugin-radar": "^0.10.0",

--- a/pb/hooks/mocks.js
+++ b/pb/hooks/mocks.js
@@ -1,72 +1,56 @@
-async function exportMocks() {
+// Dev-only helpers for the apply-mocks / export-mocks console commands.
+// Updated for the PocketBase v0.23+ API ($app.* instead of the removed
+// $app.dao()). These run only when the commands are invoked, not at startup.
+
+function exportMocks() {
   try {
-    // Initialize the collections dump object
     const snapshot = {}
 
-    // Get the list of collections
-    const baseCollections = $app.dao().findCollectionsByType('base')
-    const authCollections = $app.dao().findCollectionsByType('auth')
-    const viewCollections = $app.dao().findCollectionsByType('view')
+    const collections = $app.findAllCollections('base', 'auth', 'view')
 
-    const collections = [...baseCollections, ...authCollections, ...viewCollections]
-
-    // Iterate over each collection to fetch schema and data
     for (const collection of collections) {
-      // Fetch collection schema
-      const schema = await $app.dao().findCollectionByNameOrId(collection.name)
+      const schema = $app.findCollectionByNameOrId(collection.name)
+      const records = $app.findAllRecords(collection.name)
 
-      // Fetch all records in the collection
-      const records = await $app.dao().findRecordsByExpr(collection.name)
-
-      // Combine schema and records for each collection
       snapshot[collection.name] = {
         collection: schema,
-        items: records.map((record) => record.publicExport()) // Safely export fields
+        items: records.map((record) => record.publicExport())
       }
     }
 
     console.log(`Writing ${__hooks}/mocks.json`)
-    $os.writeFile(`${__hooks}/mocks.json`, JSON.stringify(snapshot, null, 2), 0644)
+    $os.writeFile(`${__hooks}/mocks.json`, JSON.stringify(snapshot, null, 2), 0o644)
   } catch (error) {
-    console.error('Error fetching collections:', error)
-    return c.json(500, { error: 'An error occurred while fetching collections: ' + error })
+    console.error('Error exporting mocks:', error)
   }
 }
 
-async function applyMocks() {
+function applyMocks() {
   try {
-    const db = $app.dao()
+    const mockData = JSON.parse(String.fromCharCode(...$os.readFile(`${__hooks}/mocks.json`)))
 
-    const mockData = await JSON.parse(
-      String.fromCharCode(...$os.readFile(`/${__hooks}/mocks.json`))
-    )
-
-    // Loop over each collection in the mock data
     for (const [collectionName, collectionData] of Object.entries(mockData)) {
-      // Check if the collection already exists
-      var collection = null
+      // Find or create the collection.
+      let collection = null
       try {
-        collection = await db.findCollectionByNameOrId(collectionName)
+        collection = $app.findCollectionByNameOrId(collectionName)
       } catch (err) {
-        console.log('errr: ' + err)
-        // Create the collection if it doesn't exist
         console.log(`Creating collection: ${collectionName}`)
-        const newCollection = new Collection(collectionData.collection)
-        db.saveCollection(newCollection)
+        collection = new Collection(collectionData.collection)
+        $app.save(collection)
       }
-      // Loop over each record in the collection items
+
+      // Insert any records that don't already exist.
       for (const item of collectionData.items) {
-        // Check if the record already exists by ID
         try {
-          await db.findRecordById(collectionName, item.id)
+          $app.findRecordById(collectionName, item.id)
         } catch (err) {
-          // Insert the record if it doesn't exist
+          console.log(`Inserting record ${item.id} into ${collectionName}`)
           const record = new Record(collection, item)
-          console.log(`Inserting record: ${item.id} into collection: ${collectionName}`)
           if (collection.type === 'auth') {
             record.setPassword($security.randomString(42))
           }
-          await db.saveRecord(record)
+          $app.save(record)
         }
       }
     }

--- a/pb/migrations/004_add_jobs.js
+++ b/pb/migrations/004_add_jobs.js
@@ -4,6 +4,9 @@ migrate(
     let usersCollection = app.findCollectionByNameOrId('users')
     let jobsCollection = new Collection({
       type: 'base',
+      // Pinned so later migrations (015-018) that reference this id resolve on a
+      // fresh DB, matching the id the existing production DB already has.
+      id: 'pbc_2409499253',
       name: 'jobs',
       fields: [
         {


### PR DESCRIPTION
## What & why

The app targeted **PocketBase server 0.28.4** with **JS SDK 0.26.1**. The server was ~11 minor releases behind latest (**0.39.4**, released 2026-06-14); the SDK one minor behind (**0.27.0**). This bumps both and clears two pre-existing bits of debt that blocked clean from-scratch rebuilds.

## Changes

- **`docker-compose.yaml` / `docker-compose_production.yaml`**: `PB_VERSION 0.28.4 → 0.39.4`
- **`package.json` (+ lockfile)**: `pocketbase ^0.26.1 → ^0.27.0`
- **`pb/migrations/004_add_jobs.js`**: pin the `jobs` collection id (`pbc_2409499253`). Migrations `015`–`018` reference that id directly, so on a *fresh* DB they previously failed (the id was randomly generated). Pinning reproduces the id the existing production DB already has → no-op on prod, fixes fresh rebuilds.
- **`pb/hooks/mocks.js`**: port the `export-mocks` / `apply-mocks` dev helpers off the long-removed `$app.dao()` API to the current `$app.*` API (this was already broken on 0.28).

## Validation (against the real 0.39.4 binary)

- ✅ Full migration set `001`–`018` applies cleanly on a fresh DB (previously `015` failed without the id pin).
- ✅ `jobs` collection comes up with the expected id `pbc_2409499253`.
- ✅ Hooks load without error on `serve`.
- ✅ Frontend `npm run build` passes on SDK 0.27.0.

## Notes / caveats

- PocketBase is pre-1.0; this is a large server jump, but nothing in this repo's migrations/hooks required API changes to load/apply on 0.39.4.
- `mocks.js` is a dev-only console tool — modernized but not exercised end-to-end.
- A full Docker image rebuild (`docker compose build`) downloads the 0.39.4 binary and rebuilds the UI; worth a smoke test in CI/staging before prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)