### PR TITLE
Email job submitters on submit + approval, with self-service edit/take-down link

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,12 @@
 # Get your API key from: https://console.cloud.google.com/apis/credentials
 # Enable the Google Calendar API in your Google Cloud project
 VITE_GOOGLE_CALENDAR_API_KEY=your_api_key_here
+
+# --- PocketBase server-side (set on the `pocketbase` container, not Vite) ---
+# Base URL used to build links in outgoing emails (e.g. the self-service job
+# management link). Falls back to PocketBase Settings > Application URL if unset.
+SITE_URL=https://indyhackers.com
+# Where new-job moderator notifications are sent (falls back to the SMTP sender).
+JOB_NOTIFY_EMAIL=
+# Optional Slack incoming webhook for new-job notifications.
+SLACK_WEBHOOK_URL=

--- a/pb/hooks/jobs.pb.js
+++ b/pb/hooks/jobs.pb.js
@@ -1,9 +1,19 @@
 /// <reference path="../pb_data/types.d.ts" />
 
 onRecordEnrich((e) => {
-    // hide name and email fields
-    e.record.hide('name', 'email')
+    // hide submitter contact info and the manage token
+    e.record.hide('name', 'email', 'edit_token')
 
+    e.next()
+}, "jobs")
+
+// Generate the unguessable manage token server-side before the record is
+// persisted, so the (account-less) submitter can later edit / take down their
+// own post without anyone being able to forge the link.
+onRecordCreate((e) => {
+    if (!e.record.getString("edit_token")) {
+        e.record.set("edit_token", $security.randomString(40))
+    }
     e.next()
 }, "jobs")
 
@@ -115,6 +125,90 @@ onRecordAfterCreateSuccess((e) => {
         }
     } catch (err) {
         console.error("[jobs] new-job Slack notification failed: " + err)
+    }
+
+    // --- Submitter confirmation ---
+    // Let the person who posted the job know we received it. Best-effort: a
+    // failure here must never block job creation.
+    try {
+        const settings = $app.settings()
+        const submitter = r.getString("email")
+        if (submitter) {
+            const esc = (v) =>
+                String(v == null ? "" : v)
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;")
+                    .replace(/"/g, "&quot;")
+                    .replace(/'/g, "&#39;")
+
+            const message = new MailerMessage({
+                from: { address: settings.meta.senderAddress, name: settings.meta.senderName },
+                to: [{ address: submitter }],
+                subject: "We received your job post: " + r.getString("title"),
+                html:
+                    "<h2>Thanks for posting to the IndyHackers job board!</h2>" +
+                    "<p>We received your submission for <strong>" + esc(r.getString("title")) +
+                    "</strong> at <strong>" + esc(r.getString("company")) + "</strong>.</p>" +
+                    "<p>A moderator will review it shortly. You'll get another email with a " +
+                    "management link once it's approved and live on the board.</p>"
+            })
+
+            $app.newMailClient().send(message)
+            console.log("[jobs] submitter confirmation sent to " + submitter)
+        }
+    } catch (err) {
+        console.error("[jobs] submitter confirmation failed: " + err)
+    }
+
+    e.next()
+}, "jobs")
+
+// When a moderator approves a job (approved flips false -> true), email the
+// submitter that it's live and give them a self-service link to edit the post
+// or mark it as filled. A plain edit keeps approved=true, so it won't re-fire.
+onRecordAfterUpdateSuccess((e) => {
+    const r = e.record
+
+    try {
+        const wasApproved = r.original().getBool("approved")
+        const isApproved = r.getBool("approved")
+        const submitter = r.getString("email")
+
+        if (!wasApproved && isApproved && submitter) {
+            const settings = $app.settings()
+            const esc = (v) =>
+                String(v == null ? "" : v)
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;")
+                    .replace(/"/g, "&quot;")
+                    .replace(/'/g, "&#39;")
+
+            const base = ($os.getenv("SITE_URL") || settings.meta.appURL || "").replace(/\/+$/, "")
+            const manageUrl = base + "/jobs/manage?token=" + r.getString("edit_token")
+
+            const message = new MailerMessage({
+                from: { address: settings.meta.senderAddress, name: settings.meta.senderName },
+                to: [{ address: submitter }],
+                subject: "Your job post is live: " + r.getString("title"),
+                html:
+                    "<h2>Your job post is now live!</h2>" +
+                    "<p><strong>" + esc(r.getString("title")) + "</strong> at <strong>" +
+                    esc(r.getString("company")) + "</strong> has been approved and is now on the " +
+                    "IndyHackers job board.</p>" +
+                    "<p>Need to make a change, or has the role been filled? Use your private " +
+                    "management link to edit the post or take it down:</p>" +
+                    '<p><a href="' + manageUrl + '">' + manageUrl + "</a></p>" +
+                    "<p>Keep this email — anyone with that link can manage the post.</p>"
+            })
+
+            $app.newMailClient().send(message)
+            console.log("[jobs] approval email sent to " + submitter)
+        }
+    } catch (err) {
+        // Never let a notification failure block the approval.
+        console.error("[jobs] approval email failed: " + err)
     }
 
     e.next()

--- a/pb/hooks/jobs_manage.pb.js
+++ b/pb/hooks/jobs_manage.pb.js
@@ -1,0 +1,106 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+// Self-service job management for account-less submitters. Authority is the
+// unguessable `edit_token` minted on create (see jobs.pb.js) and delivered in
+// the approval email. These endpoints look the job up by that token and never
+// expose the submitter's name/email or the token itself.
+//
+// NOTE: PocketBase runs each routerAdd handler in an isolated JSVM runtime, so
+// helpers cannot be shared from the file scope — they are inlined per handler.
+
+routerAdd("GET", "/api/jobs/manage/{token}", (e) => {
+    const publicView = (r) => ({
+        id: r.id,
+        title: r.getString("title"),
+        company: r.getString("company"),
+        salary_min: r.getInt("salary_min"),
+        salary_max: r.getInt("salary_max"),
+        description: r.getString("description"),
+        how_to_apply: r.getString("how_to_apply"),
+        approved: r.getBool("approved"),
+        filled: r.getBool("filled")
+    })
+
+    const token = e.request.pathValue("token")
+    let job = null
+    if (token) {
+        try {
+            job = $app.findFirstRecordByData("jobs", "edit_token", token)
+        } catch (err) {
+            job = null
+        }
+    }
+    if (!job) {
+        throw new NotFoundError("No job matches that link.")
+    }
+    return e.json(200, publicView(job))
+})
+
+routerAdd("PATCH", "/api/jobs/manage/{token}", (e) => {
+    const EDITABLE = ["title", "company", "salary_min", "salary_max", "description", "how_to_apply"]
+    const stripTags = (v) => String(v == null ? "" : v).replace(/<[^>]*>/g, "").trim()
+    const publicView = (r) => ({
+        id: r.id,
+        title: r.getString("title"),
+        company: r.getString("company"),
+        salary_min: r.getInt("salary_min"),
+        salary_max: r.getInt("salary_max"),
+        description: r.getString("description"),
+        how_to_apply: r.getString("how_to_apply"),
+        approved: r.getBool("approved"),
+        filled: r.getBool("filled")
+    })
+
+    const token = e.request.pathValue("token")
+    let job = null
+    if (token) {
+        try {
+            job = $app.findFirstRecordByData("jobs", "edit_token", token)
+        } catch (err) {
+            job = null
+        }
+    }
+    if (!job) {
+        throw new NotFoundError("No job matches that link.")
+    }
+
+    const body = e.requestInfo().body || {}
+
+    // Editable text/number fields (only those actually provided).
+    for (const key of EDITABLE) {
+        if (body[key] === undefined) continue
+
+        if (key === "salary_min" || key === "salary_max") {
+            const n = Number(body[key])
+            if (isNaN(n) || n < 0 || n > 1000) {
+                throw new BadRequestError("Salary must be a number between 0 and 1000.")
+            }
+            job.set(key, n)
+        } else if (key === "description" || key === "how_to_apply") {
+            if (stripTags(body[key]).length === 0) {
+                throw new BadRequestError("Description and how-to-apply cannot be empty.")
+            }
+            job.set(key, String(body[key]))
+        } else {
+            if (String(body[key]).trim().length === 0) {
+                throw new BadRequestError("Title and company cannot be empty.")
+            }
+            job.set(key, String(body[key]))
+        }
+    }
+
+    const min = job.getInt("salary_min")
+    const max = job.getInt("salary_max")
+    if (max > 0 && max < min) {
+        throw new BadRequestError("Minimum salary is greater than maximum.")
+    }
+
+    // Soft take-down. Edits otherwise leave `approved` untouched, so they stay
+    // live without re-triggering moderation or the approval email.
+    if (body.filled !== undefined) {
+        job.set("filled", !!body.filled)
+    }
+
+    $app.save(job)
+    return e.json(200, publicView(job))
+})

--- a/pb/migrations/019_add_edit_token_and_filled_to_jobs.js
+++ b/pb/migrations/019_add_edit_token_and_filled_to_jobs.js
@@ -1,0 +1,52 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_2409499253")
+
+  // Unguessable per-job token that lets the (account-less) submitter manage
+  // their own post via the /api/jobs/manage endpoints. Set server-side by the
+  // onRecordCreate hook; hidden so it never leaks through the normal API.
+  collection.fields.addAt(50, new Field({
+    "hidden": true,
+    "id": "text_edit_token",
+    "name": "edit_token",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "text"
+  }))
+
+  // Soft take-down: a filled job is kept but excluded from the public list.
+  collection.fields.addAt(51, new Field({
+    "hidden": false,
+    "id": "bool_filled",
+    "name": "filled",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "bool"
+  }))
+
+  // Fast, collision-proof lookup by token (partial index skips the empty
+  // tokens backfilled rows briefly have before the UPDATE below).
+  collection.indexes = [
+    ...collection.indexes,
+    "CREATE UNIQUE INDEX `idx_jobs_edit_token` ON `jobs` (`edit_token`) WHERE `edit_token` != ''"
+  ]
+
+  app.save(collection)
+
+  // Backfill a token for every pre-existing job (40 hex chars via SQLite).
+  app.db().newQuery(
+    "UPDATE jobs SET edit_token = lower(hex(randomblob(20))) WHERE edit_token IS NULL OR edit_token = ''"
+  ).execute()
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_2409499253")
+
+  collection.indexes = collection.indexes.filter(
+    (idx) => !idx.includes("idx_jobs_edit_token")
+  )
+  collection.fields.removeById("text_edit_token")
+  collection.fields.removeById("bool_filled")
+
+  return app.save(collection)
+})

--- a/src/components/__tests__/ManageJobView.spec.js
+++ b/src/components/__tests__/ManageJobView.spec.js
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import ManageJobView from '../jobs/ManageJobView.vue'
+
+const mockJob = {
+  id: 'job1',
+  title: 'Senior Developer',
+  company: 'Acme Corp',
+  salary_min: 100,
+  salary_max: 150,
+  description: '<p>Great opportunity</p>',
+  how_to_apply: '<p>Email hr@acme.com</p>',
+  approved: true,
+  filled: false
+}
+
+function createMockPocketBase(send) {
+  return { send: send || vi.fn().mockResolvedValue({ ...mockJob }) }
+}
+
+function mountView(pb, routeQuery = { token: 'tok123' }) {
+  return mount(ManageJobView, {
+    global: {
+      config: {
+        globalProperties: {
+          pocketbase: pb,
+          $route: { query: routeQuery }
+        }
+      },
+      stubs: {
+        'b-row': { template: '<div><slot /></div>' },
+        'b-col': { template: '<div><slot /></div>' },
+        'b-form': { template: '<form @submit="$emit(\'submit\', $event)"><slot /></form>' },
+        'b-form-group': { template: '<div><slot /></div>' },
+        'b-form-input': { template: '<input />' },
+        'b-input-group': { template: '<div><slot /></div>' },
+        'b-button': { template: '<button @click="$emit(\'click\')"><slot /></button>' },
+        'b-alert': { template: '<div class="b-alert"><slot /></div>' },
+        'tip-tap-editor': { template: '<div class="tiptap-stub"></div>' }
+      }
+    }
+  })
+}
+
+describe('ManageJobView', () => {
+  let pb
+
+  beforeEach(() => {
+    pb = createMockPocketBase()
+  })
+
+  it('loads the job via the token-scoped manage endpoint', async () => {
+    mountView(pb)
+    await flushPromises()
+
+    expect(pb.send).toHaveBeenCalledWith('/api/jobs/manage/tok123', { method: 'GET' })
+  })
+
+  it('shows an error when no token is present', async () => {
+    const wrapper = mountView(pb, {})
+    await flushPromises()
+
+    expect(pb.send).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('missing its token')
+  })
+
+  it('shows a not-found error when the endpoint rejects', async () => {
+    const send = vi.fn().mockRejectedValue(new Error('404'))
+    const wrapper = mountView(createMockPocketBase(send))
+    await flushPromises()
+
+    expect(wrapper.text()).toContain("couldn't find a job")
+  })
+
+  it('saves edits with a PATCH to the manage endpoint', async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({ ...mockJob })
+      .mockResolvedValueOnce({ ...mockJob, title: 'Lead Developer' })
+    const wrapper = mountView(createMockPocketBase(send))
+    await flushPromises()
+
+    await wrapper.find('form').trigger('submit')
+    await flushPromises()
+
+    expect(send).toHaveBeenLastCalledWith(
+      '/api/jobs/manage/tok123',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: expect.objectContaining({ title: 'Senior Developer', company: 'Acme Corp' })
+      })
+    )
+  })
+
+  it('marks the job as filled after confirmation', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({ ...mockJob })
+      .mockResolvedValueOnce({ ...mockJob, filled: true })
+    const wrapper = mountView(createMockPocketBase(send))
+    await flushPromises()
+
+    const takedownBtn = wrapper.findAll('button').find((b) => b.text().includes('Mark as filled'))
+    await takedownBtn.trigger('click')
+    await flushPromises()
+
+    expect(send).toHaveBeenLastCalledWith(
+      '/api/jobs/manage/tok123',
+      expect.objectContaining({ method: 'PATCH', body: { filled: true } })
+    )
+    confirmSpy.mockRestore()
+  })
+
+  it('does not take down the job if confirmation is cancelled', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const send = vi.fn().mockResolvedValue({ ...mockJob })
+    const wrapper = mountView(createMockPocketBase(send))
+    await flushPromises()
+
+    const takedownBtn = wrapper.findAll('button').find((b) => b.text().includes('Mark as filled'))
+    await takedownBtn.trigger('click')
+    await flushPromises()
+
+    // only the initial GET happened — no PATCH
+    expect(send).toHaveBeenCalledTimes(1)
+    confirmSpy.mockRestore()
+  })
+})

--- a/src/components/jobs/JobsList.vue
+++ b/src/components/jobs/JobsList.vue
@@ -41,7 +41,7 @@ export default defineComponent({
         const jobs = await this.pocketbase.collection('jobs').getList(
           1, 100,{
             sort: '-approved_at',
-            filter: `approved = true && approved_at != "" && approved_at >= "${cutoff}"`
+            filter: `approved = true && filled != true && approved_at != "" && approved_at >= "${cutoff}"`
         })
         this.jobs = jobs.items
       } catch (error) {

--- a/src/components/jobs/ManageJobView.vue
+++ b/src/components/jobs/ManageJobView.vue
@@ -1,0 +1,234 @@
+<template>
+  <div class="manage-job">
+    <div class="ih-container">
+      <h1 class="title">Manage Your Job Post</h1>
+
+      <b-alert :model-value="!!error" variant="danger">{{ error }}</b-alert>
+      <b-alert v-model="notice.visible" :variant="notice.variant" dismissable>{{
+        notice.message
+      }}</b-alert>
+
+      <p v-if="loading" class="subtitle">Loading…</p>
+
+      <div v-else-if="job">
+        <b-alert :model-value="job.filled" variant="warning">
+          This post is marked as <strong>filled</strong> and is hidden from the public job board.
+        </b-alert>
+
+        <b-form @submit.prevent="save">
+          <b-row>
+            <b-col md="6">
+              <b-form-group label="Job Title" label-for="input-title">
+                <b-form-input id="input-title" v-model="formData.title" required></b-form-input>
+              </b-form-group>
+            </b-col>
+            <b-col md="6">
+              <b-form-group label="Company" label-for="input-company">
+                <b-form-input id="input-company" v-model="formData.company" required></b-form-input>
+              </b-form-group>
+            </b-col>
+          </b-row>
+
+          <b-row class="mt-3">
+            <b-form-group label="Salary Range (Optional)" class="w-100">
+              <div class="d-flex align-items-center">
+                <b-input-group append="K" class="w-auto" style="max-width: 120px;">
+                  <b-form-input type="number" id="input-salary-min" v-model="formData.salary_min" :min="0" :max="1000"></b-form-input>
+                </b-input-group>
+                <span class="mx-2">-</span>
+                <b-input-group append="K" class="w-auto" style="max-width: 120px;">
+                  <b-form-input type="number" id="input-salary-max" v-model="formData.salary_max" :min="0" :max="1000"></b-form-input>
+                </b-input-group>
+              </div>
+            </b-form-group>
+          </b-row>
+
+          <b-row class="mt-3">
+            <b-col cols="12">
+              <b-form-group label="Description">
+                <tip-tap-editor class="tip-tap-description" v-model="formData.description" />
+              </b-form-group>
+            </b-col>
+          </b-row>
+          <b-row class="mt-3">
+            <b-col cols="12">
+              <b-form-group label="How to Apply">
+                <tip-tap-editor class="tip-tap-how-to-apply" v-model="formData.how_to_apply" />
+              </b-form-group>
+            </b-col>
+          </b-row>
+
+          <b-row class="mt-3">
+            <b-col cols="12" class="d-flex justify-content-between">
+              <b-button
+                v-if="!job.filled"
+                variant="outline-danger"
+                type="button"
+                :disabled="saving"
+                @click="markFilled"
+              >Mark as filled / take down</b-button>
+              <b-button
+                v-else
+                variant="outline-secondary"
+                type="button"
+                :disabled="saving"
+                @click="relist"
+              >Re-list this job</b-button>
+
+              <b-button variant="primary" type="submit" :disabled="saving">Save changes</b-button>
+            </b-col>
+          </b-row>
+        </b-form>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { defineComponent } from 'vue'
+import TipTapEditor from '../TipTapEditor.vue'
+
+export default defineComponent({
+  name: 'ManageJobView',
+  components: { TipTapEditor },
+  data() {
+    return {
+      token: '',
+      job: null,
+      loading: true,
+      saving: false,
+      error: '',
+      formData: {
+        title: '',
+        company: '',
+        salary_min: 0,
+        salary_max: 0,
+        description: '',
+        how_to_apply: ''
+      },
+      notice: { message: '', visible: false, variant: 'success' }
+    }
+  },
+  methods: {
+    async load() {
+      this.token = this.$route.query.token || ''
+      if (!this.token) {
+        this.error = 'This management link is missing its token. Please use the link from your approval email.'
+        this.loading = false
+        return
+      }
+      try {
+        const job = await this.pocketbase.send(`/api/jobs/manage/${encodeURIComponent(this.token)}`, {
+          method: 'GET'
+        })
+        this.setJob(job)
+      } catch (err) {
+        console.error('Error loading job:', err)
+        this.error = 'We couldn\'t find a job for this link. It may have been removed, or the link may be incorrect.'
+      } finally {
+        this.loading = false
+      }
+    },
+    setJob(job) {
+      this.job = job
+      this.formData = {
+        title: job.title || '',
+        company: job.company || '',
+        salary_min: job.salary_min || 0,
+        salary_max: job.salary_max || 0,
+        description: job.description || '',
+        how_to_apply: job.how_to_apply || ''
+      }
+    },
+    validate() {
+      if (Number(this.formData.salary_max) < Number(this.formData.salary_min) && Number(this.formData.salary_max) > 0) {
+        throw new Error('Minimum salary is greater than maximum')
+      }
+      if (this.formData.description == null || this.formData.description.replace(/<[^>]*>/g, '').trim().length === 0) {
+        throw new Error('Job description is empty')
+      }
+      if (this.formData.how_to_apply == null || this.formData.how_to_apply.replace(/<[^>]*>/g, '').trim().length === 0) {
+        throw new Error('How to apply details are empty')
+      }
+    },
+    async patch(body, successMessage) {
+      this.saving = true
+      try {
+        const updated = await this.pocketbase.send(`/api/jobs/manage/${encodeURIComponent(this.token)}`, {
+          method: 'PATCH',
+          body
+        })
+        this.setJob(updated)
+        this.showNotice(successMessage, 'success')
+      } catch (err) {
+        const message = err?.response?.message || err?.message || 'Something went wrong'
+        this.showNotice(`Error: ${message}`, 'danger')
+      } finally {
+        this.saving = false
+      }
+    },
+    async save() {
+      try {
+        this.validate()
+      } catch (err) {
+        this.showNotice(`Error: ${err.message}`, 'danger')
+        return
+      }
+      await this.patch(
+        {
+          title: this.formData.title,
+          company: this.formData.company,
+          salary_min: Number(this.formData.salary_min),
+          salary_max: Number(this.formData.salary_max),
+          description: this.formData.description,
+          how_to_apply: this.formData.how_to_apply
+        },
+        'Your changes have been saved.'
+      )
+    },
+    async markFilled() {
+      if (!window.confirm('Mark this job as filled? It will be removed from the public job board.')) {
+        return
+      }
+      await this.patch({ filled: true }, 'Your job has been taken down.')
+    },
+    async relist() {
+      await this.patch({ filled: false }, 'Your job has been re-listed.')
+    },
+    showNotice(message, variant) {
+      this.notice = { message, visible: true, variant }
+      try {
+        window.scrollTo({ top: 0 })
+      } catch {
+        /* jsdom / unsupported environments */
+      }
+    }
+  },
+  mounted() {
+    this.load()
+  }
+})
+</script>
+
+<style scoped>
+.manage-job {
+  background-color: var(--surface-2);
+  padding: 3rem 0;
+}
+.title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: bold;
+  color: var(--text-primary);
+  margin-bottom: 1rem;
+}
+.subtitle {
+  font-size: 1.2rem;
+  color: var(--text-secondary);
+}
+:deep(.tip-tap-description .tiptap.ProseMirror) {
+  min-height: 150px;
+}
+:deep(.tip-tap-how-to-apply .tiptap.ProseMirror) {
+  min-height: 75px;
+}
+</style>

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -172,6 +172,19 @@ const mockCalendarEvents = {
   ]
 }
 
+// In-memory job used by the self-service manage endpoints during local dev.
+let manageJob = {
+  id: 'managejob1',
+  title: 'Senior Frontend Engineer',
+  company: 'Sample Co',
+  salary_min: 90,
+  salary_max: 140,
+  description: '<p>Build delightful UIs with Vue.</p>',
+  how_to_apply: '<p>Email jobs@sample.co</p>',
+  approved: true,
+  filled: false
+}
+
 export const handlers = [
   http.get('https://www.googleapis.com/calendar/v3/calendars/:calendarId/events', () => {
     return HttpResponse.json(mockCalendarEvents)
@@ -239,5 +252,13 @@ export const handlers = [
     } else {
       return HttpResponse.json({ error: 'Record not found' }, { status: 404 })
     }
+  }),
+  http.get('/api/jobs/manage/:token', () => {
+    return HttpResponse.json(manageJob)
+  }),
+  http.patch('/api/jobs/manage/:token', async ({ request }) => {
+    const body = JSON.parse(await request.text())
+    manageJob = { ...manageJob, ...body }
+    return HttpResponse.json(manageJob)
   })
 ]

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -30,6 +30,11 @@ const router = createRouter({
       component: () => import('../components/jobs/JobsMarkdown.vue')
     },
     {
+      path: '/jobs/manage',
+      name: 'ManageJob',
+      component: () => import('../components/jobs/ManageJobView.vue')
+    },
+    {
       path: '/about',
       name: 'About',
       component: () => import('../views/AboutView.vue')


### PR DESCRIPTION
## Summary

Job submitters are account-less and currently receive **no** communication — they don't know their post was received, don't know when it goes live, and can't update or remove it. This adds three submitter-facing touchpoints:

1. **Confirmation email** on submit ("received, pending review").
2. **Approval email** when a moderator approves it ("it's live"), containing a private management link.
3. A **self-service `/jobs/manage?token=…` page** (no login) to **edit** the post or **mark it as filled** (take it down).

The existing moderator/Slack notification (PR #60) is unchanged.

> Confirmed product decisions: take-down is a **soft "filled"** flag (record kept, hidden from the board); edits to an approved job **go live immediately** and do not re-trigger moderation or the approval email.

## Security model

The submitter has no account, so authority is an unguessable **`edit_token`** (`$security.randomString(40)`) minted **server-side** on create and **hidden from all normal API reads**. All submitter read/write goes through token-scoped custom endpoints that return only editable fields — never `name`/`email`/`edit_token`.

## Changes

**Backend (`pb/`)**
- **`migration 019`** — adds hidden `edit_token` (unique partial index, backfilled for existing rows) and `filled` to the `jobs` collection.
- **`jobs.pb.js`** — mint `edit_token` on create; hide it on enrich; send the submitter confirmation (in the existing `onRecordAfterCreateSuccess`) and the approval email with the manage link (new `onRecordAfterUpdateSuccess`, only on the `approved` false→true flip). Link base = `SITE_URL` env, falling back to PocketBase's Application URL.
- **`jobs_manage.pb.js`** — `GET`/`PATCH /api/jobs/manage/{token}` (helpers inlined per handler, since PocketBase runs each `routerAdd` handler in an isolated runtime).

**Frontend (`src/`)**
- `ManageJobView.vue` + `/jobs/manage` route; MSW handlers + a vitest spec.
- `JobsList` filter now excludes `filled` jobs.

**Docs** — `SITE_URL` (and the previously-undocumented `JOB_NOTIFY_EMAIL` / `SLACK_WEBHOOK_URL` server vars) added to `.env.example`.

## Verification

Ran against a **real PocketBase 0.39.4** instance with the project's migrations + hooks and a local SMTP sink:

| Check | Result |
|---|---|
| Migration applies; `edit_token` hidden, `filled` added | ✅ |
| Token minted on create, never returned by the API | ✅ |
| Confirmation email on submit → submitter | ✅ |
| Approval email on approve → submitter, with a manage link whose token **matches the record** | ✅ |
| `GET` manage: valid → 200 (no contact fields), bad token → 404 | ✅ |
| `PATCH` edit + validation (salary range / empty body → 400) | ✅ |
| Soft take-down (`filled: true`) hides the job from the board | ✅ |
| Editing an approved job does **not** resend the approval email | ✅ |
| `npm run build` + `npm run test:unit` | ✅ (new specs pass; the 2 pre-existing `LoginPage`/`SignupPage` failures are unrelated) |

## Deploy notes

- **SMTP** must be configured in PocketBase for any mail to send (shared requirement with #60/#61).
- For correct links, set **`SITE_URL`** on the `pocketbase` container, or ensure PocketBase's **Application URL** is the real site origin.
- ⚠️ Migration is numbered `019`; PR #61 (events) also introduces `019–024`. Whichever merges second should renumber to avoid a collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)