### PR TITLE
Fix 404 on Panfactum sponsor link

### DIFF
--- a/src/views/SponsorsView.vue
+++ b/src/views/SponsorsView.vue
@@ -140,7 +140,7 @@ const sponsors = ref([
   {
     id: 5,
     name: 'Panfactum',
-    link: 'https://www.panfactum.com/?utm_campaign=indy_hackers',
+    link: 'https://panfactum.com',
     logo: '/images/sponsors/panfactum-logo.png'
   }
 ])

--- a/src/views/SponsorsView.vue
+++ b/src/views/SponsorsView.vue
@@ -140,7 +140,7 @@ const sponsors = ref([
   {
     id: 5,
     name: 'Panfactum',
-    link: 'https://panfactum.com',
+    link: 'https://panfactum.com/?utm_campaign=indy_hackers',
     logo: '/images/sponsors/panfactum-logo.png'
   }
 ])


### PR DESCRIPTION
## Summary

The **Panfactum** entry on the Sponsors page linked to `https://www.panfactum.com/?utm_campaign=indy_hackers`, which now returns a **404** (the `www.` host is no longer served). This points it at the working apex domain while keeping the sponsor-attribution UTM param.

## Change

`src/views/SponsorsView.vue` — Panfactum `link`:
- `https://www.panfactum.com/?utm_campaign=indy_hackers` → `https://panfactum.com/?utm_campaign=indy_hackers`

## Verification

```
404  https://www.panfactum.com/?utm_campaign=indy_hackers   (old — broken)
200  https://panfactum.com/?utm_campaign=indy_hackers        (new — keeps UTM attribution)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)