### PR TITLE
SEO 1/4: per-route meta tags (unhead)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tiptap/pm": "^2.6.6",
         "@tiptap/starter-kit": "^2.6.6",
         "@tiptap/vue-3": "^2.6.6",
+        "@unhead/vue": "^2.1.15",
         "bootstrap": "^5.3.3",
         "bootstrap-vue-next": "^0.24.2",
         "dompurify": "^3.3.2",
@@ -1424,9 +1425,10 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
@@ -2352,6 +2354,28 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "node_modules/@unhead/vue": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.15.tgz",
+      "integrity": "sha512-SSByXfEjhzPn8gXdEdgpYqpLMPSkLUH2HVE0GxZfOtNsJ0GgOHQs0g9T67ZZ1z0kTELLKdtOtYrzrbv9+ffF7g==",
+      "license": "MIT",
+      "dependencies": {
+        "hookable": "^6.0.1",
+        "unhead": "2.1.15"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "vue": ">=3.5.18"
+      }
+    },
+    "node_modules/@unhead/vue/node_modules/hookable": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
+      "license": "MIT"
+    },
     "node_modules/@vitejs/plugin-vue": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
@@ -2524,13 +2548,6 @@
         }
       }
     },
-    "node_modules/@vue/babel-plugin-jsx/node_modules/@vue/shared": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
-      "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@vue/babel-plugin-resolve-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@vue/babel-plugin-resolve-type/-/babel-plugin-resolve-type-1.4.0.tgz",
@@ -2551,83 +2568,24 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@vue/babel-plugin-resolve-type/node_modules/@vue/compiler-core": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.17.tgz",
-      "integrity": "sha512-Xe+AittLbAyV0pabcN7cP7/BenRBNcteM4aSDCtRvGw0d9OL+HG1u/XHLY/kt1q4fyMeZYXyIYrsHuPSiDPosA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/shared": "3.5.17",
-        "entities": "^4.5.0",
-        "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/babel-plugin-resolve-type/node_modules/@vue/compiler-dom": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.17.tgz",
-      "integrity": "sha512-+2UgfLKoaNLhgfhV5Ihnk6wB4ljyW1/7wUIog2puUqajiC29Lp5R/IKDdkebh9jTbTogTbsgB+OY9cEWzG95JQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-core": "3.5.17",
-        "@vue/shared": "3.5.17"
-      }
-    },
-    "node_modules/@vue/babel-plugin-resolve-type/node_modules/@vue/compiler-sfc": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.17.tgz",
-      "integrity": "sha512-rQQxbRJMgTqwRugtjw0cnyQv9cP4/4BxWfTdRBkqsTfLOHWykLzbOc3C4GGzAmdMDxhzU/1Ija5bTjMVrddqww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.27.5",
-        "@vue/compiler-core": "3.5.17",
-        "@vue/compiler-dom": "3.5.17",
-        "@vue/compiler-ssr": "3.5.17",
-        "@vue/shared": "3.5.17",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
-        "postcss": "^8.5.6",
-        "source-map-js": "^1.2.1"
-      }
-    },
-    "node_modules/@vue/babel-plugin-resolve-type/node_modules/@vue/compiler-ssr": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.17.tgz",
-      "integrity": "sha512-hkDbA0Q20ZzGgpj5uZjb9rBzQtIHLS78mMilwrlpWk2Ep37DYntUz0PonQ6kr113vfOEdM+zTBuJDaceNIW0tQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vue/compiler-dom": "3.5.17",
-        "@vue/shared": "3.5.17"
-      }
-    },
-    "node_modules/@vue/babel-plugin-resolve-type/node_modules/@vue/shared": {
-      "version": "3.5.17",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.17.tgz",
-      "integrity": "sha512-CabR+UN630VnsJO/jHWYBC1YVXyMq94KKp6iF5MQgZJs5I8cmjw6oVMO1oDbtBkENSHSSn/UadWlW/OAgdmKrg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@vue/compiler-core": {
-      "version": "3.4.36",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.4.36.tgz",
-      "integrity": "sha512-qBkndgpwFKdupmOPoiS10i7oFdN7a+4UNDlezD0GlQ1kuA1pNrscg9g12HnB5E8hrWSuEftRsbJhL1HI2zpJhg==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
+      "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.24.7",
-        "@vue/shared": "3.4.36",
-        "entities": "^5.0.0",
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.39",
+        "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
-        "source-map-js": "^1.2.0"
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-core/node_modules/entities": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-5.0.0.tgz",
-      "integrity": "sha512-BeJFvFRJddxobhvEdm5GqHzRV/X+ACeuw0/BuuxsCh1EUZcAIz8+kYmBp/LrQuloy6K1f3a0M7+IhmZ7QnkISA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -2636,37 +2594,40 @@
       }
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.4.36",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.4.36.tgz",
-      "integrity": "sha512-eEIjy4GwwZTFon/Y+WO8tRRNGqylaRlA79T1RLhUpkOzJ7EtZkkb8MurNfkqY6x6Qiu0R7ESspEF7GkPR/4yYg==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
+      "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.4.36",
-        "@vue/shared": "3.4.36"
+        "@vue/compiler-core": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.4.36",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.4.36.tgz",
-      "integrity": "sha512-rhuHu7qztt/rNH90dXPTzhB7hLQT2OC4s4GrPVqmzVgPY4XBlfWmcWzn4bIPEWNImt0CjO7kfHAf/1UXOtx3vw==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.39.tgz",
+      "integrity": "sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.24.7",
-        "@vue/compiler-core": "3.4.36",
-        "@vue/compiler-dom": "3.4.36",
-        "@vue/compiler-ssr": "3.4.36",
-        "@vue/shared": "3.4.36",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.39",
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.10",
-        "postcss": "^8.4.40",
-        "source-map-js": "^1.2.0"
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
+        "source-map-js": "^1.2.1"
       }
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.4.36",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.4.36.tgz",
-      "integrity": "sha512-Wt1zyheF0zVvRJyhY74uxQbnkXV2Le/JPOrAxooR4rFYKC7cFr+cRqW6RU3cM/bsTy7sdZ83IDuy/gLPSfPGng==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
+      "integrity": "sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.36",
-        "@vue/shared": "3.4.36"
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/devtools-api": {
@@ -2752,49 +2713,54 @@
       }
     },
     "node_modules/@vue/reactivity": {
-      "version": "3.4.36",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.4.36.tgz",
-      "integrity": "sha512-wN1aoCwSoqrt1yt8wO0gc13QaC+Vk1o6AoSt584YHNnz6TGDhh1NCMUYgAnvp4HEIkLdGsaC1bvu/P+wpoDEXw==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
+      "integrity": "sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/shared": "3.4.36"
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/runtime-core": {
-      "version": "3.4.36",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.4.36.tgz",
-      "integrity": "sha512-9+TR14LAVEerZWLOm/N/sG2DVYhrH2bKgFrbH/FVt/Q8Jdw4OtdcGMRC6Tx8VAo0DA1eqAqrZaX0fbOaOxxZ4A==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.39.tgz",
+      "integrity": "sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.4.36",
-        "@vue/shared": "3.4.36"
+        "@vue/reactivity": "3.5.39",
+        "@vue/shared": "3.5.39"
       }
     },
     "node_modules/@vue/runtime-dom": {
-      "version": "3.4.36",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.4.36.tgz",
-      "integrity": "sha512-2Qe2fKkLxgZBVvHrG0QMNLL4bsx7Ae88pyXebY2WnQYABpOnGYvA+axMbcF9QwM4yxnsv+aELbC0eiNVns7mGw==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.39.tgz",
+      "integrity": "sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/reactivity": "3.4.36",
-        "@vue/runtime-core": "3.4.36",
-        "@vue/shared": "3.4.36",
-        "csstype": "^3.1.3"
+        "@vue/reactivity": "3.5.39",
+        "@vue/runtime-core": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "csstype": "^3.2.3"
       }
     },
     "node_modules/@vue/server-renderer": {
-      "version": "3.4.36",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.4.36.tgz",
-      "integrity": "sha512-2XW90Rq8+Y7S1EIsAuubZVLm0gCU8HYb5mRAruFdwfC3XSOU5/YKePz29csFzsch8hXaY5UHh7ZMddmi1XTJEA==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.39.tgz",
+      "integrity": "sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-ssr": "3.4.36",
-        "@vue/shared": "3.4.36"
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39"
       },
       "peerDependencies": {
-        "vue": "3.4.36"
+        "vue": "3.5.39"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.4.36",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.4.36.tgz",
-      "integrity": "sha512-fdPLStwl1sDfYuUftBaUVn2pIrVFDASYerZSrlBvVBfylObPA1gtcWJHy5Ox8jLEJ524zBibss488Q3SZtU1uA=="
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
+      "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
+      "license": "MIT"
     },
     "node_modules/@vue/test-utils": {
       "version": "2.4.6",
@@ -2899,10 +2865,11 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3547,9 +3514,10 @@
       "dev": true
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -5078,12 +5046,12 @@
       "dev": true
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/markdown-it": {
@@ -5209,15 +5177,16 @@
       "license": "MIT"
     },
     "node_modules/mlly": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.4.tgz",
-      "integrity": "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "acorn": "^8.14.0",
-        "pathe": "^2.0.1",
-        "pkg-types": "^1.3.0",
-        "ufo": "^1.5.4"
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
       }
     },
     "node_modules/mrmime": {
@@ -6712,10 +6681,29 @@
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
     },
     "node_modules/ufo": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
-      "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==",
-      "dev": true
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unhead": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.15.tgz",
+      "integrity": "sha512-MCt5T90mCWyr3Z6pUCdM9lVRXoMoVBlL7z7U4CYVIiaDiuzad/UCfLuMqz5MeNmpZUgoBCQnrucJimU7EZR+XA==",
+      "license": "MIT",
+      "dependencies": {
+        "hookable": "^6.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
+    "node_modules/unhead/node_modules/hookable": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.2.0",
@@ -7285,15 +7273,16 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.4.36",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.4.36.tgz",
-      "integrity": "sha512-mIFvbLgjODfx3Iy1SrxOsiPpDb8Bo3EU+87ioimOZzZTOp15IEdAels70IjBOLO3ZFlLW5AhdwY4dWbXVQKYow==",
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
+      "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
+      "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.4.36",
-        "@vue/compiler-sfc": "3.4.36",
-        "@vue/runtime-dom": "3.4.36",
-        "@vue/server-renderer": "3.4.36",
-        "@vue/shared": "3.4.36"
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-sfc": "3.5.39",
+        "@vue/runtime-dom": "3.5.39",
+        "@vue/server-renderer": "3.5.39",
+        "@vue/shared": "3.5.39"
       },
       "peerDependencies": {
         "typescript": "*"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@tiptap/pm": "^2.6.6",
     "@tiptap/starter-kit": "^2.6.6",
     "@tiptap/vue-3": "^2.6.6",
+    "@unhead/vue": "^2.1.15",
     "bootstrap": "^5.3.3",
     "bootstrap-vue-next": "^0.24.2",
     "dompurify": "^3.3.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,6 +12,13 @@
 import { RouterView } from 'vue-router'
 import NavigationBar from './components/NavigationBar.vue'
 import BottomLinkTree from './components/BottomLinkTree.vue'
+import {
+  SITE_NAME,
+  DEFAULT_DESCRIPTION,
+  DEFAULT_OG_IMAGE,
+  pageTitle,
+  canonicalUrl
+} from '@/seo'
 
 export default {
   name: 'App',
@@ -19,6 +26,33 @@ export default {
     NavigationBar,
     BottomLinkTree,
     RouterView
+  },
+  // Site-wide, route-driven document head. Each route supplies its own
+  // `meta.title` / `meta.description` (see router); pages with dynamic content
+  // (e.g. a single job listing) override title/description via their own
+  // `head()` option, which unhead dedupes so the more specific page wins.
+  head() {
+    const meta = this.$route.meta || {}
+    const title = pageTitle(meta.title)
+    const description = meta.description || DEFAULT_DESCRIPTION
+    const url = canonicalUrl(this.$route.path)
+    return {
+      title,
+      link: [{ rel: 'canonical', href: url }],
+      meta: [
+        { name: 'description', content: description },
+        { property: 'og:type', content: 'website' },
+        { property: 'og:site_name', content: SITE_NAME },
+        { property: 'og:title', content: title },
+        { property: 'og:description', content: description },
+        { property: 'og:url', content: url },
+        { property: 'og:image', content: DEFAULT_OG_IMAGE },
+        { name: 'twitter:card', content: 'summary_large_image' },
+        { name: 'twitter:title', content: title },
+        { name: 'twitter:description', content: description },
+        { name: 'twitter:image', content: DEFAULT_OG_IMAGE }
+      ]
+    }
   },
   computed: {
     isLoggedIn() {

--- a/src/__tests__/seo.spec.js
+++ b/src/__tests__/seo.spec.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createHead, renderDOMHead } from '@unhead/vue/client'
+import { VueHeadMixin } from '@unhead/vue'
+import { SITE_URL, SITE_NAME, DEFAULT_TITLE, pageTitle, canonicalUrl } from '@/seo'
+
+describe('seo helpers', () => {
+  it('pageTitle suffixes the site name, falling back to the default title', () => {
+    expect(pageTitle('About')).toBe(`About · ${SITE_NAME}`)
+    expect(pageTitle('')).toBe(DEFAULT_TITLE)
+    expect(pageTitle(undefined)).toBe(DEFAULT_TITLE)
+  })
+
+  it('canonicalUrl builds an absolute URL and strips query/hash', () => {
+    expect(canonicalUrl('/jobs')).toBe(`${SITE_URL}/jobs`)
+    expect(canonicalUrl('/job?id=abc')).toBe(`${SITE_URL}/job`)
+    expect(canonicalUrl('/x#frag')).toBe(`${SITE_URL}/x`)
+    expect(canonicalUrl(undefined)).toBe(`${SITE_URL}/`)
+  })
+})
+
+// Verifies the actual unhead wiring used in main.js: createHead() + the
+// VueHeadMixin that powers the Options-API `head()` option App.vue relies on.
+describe('unhead head() wiring', () => {
+  afterEach(() => {
+    document.head.innerHTML = ''
+    document.title = ''
+  })
+
+  let head
+  function mountWithHead(component) {
+    head = createHead()
+    return mount(component, { global: { plugins: [head], mixins: [VueHeadMixin] } })
+  }
+  // unhead's client renderer is rAF-debounced; force a synchronous flush so the
+  // assertions don't race the DOM write.
+  const renderHead = () => renderDOMHead(head)
+
+  it('renders a reactive head() option to the document', async () => {
+    const Comp = {
+      data: () => ({ title: 'About', description: 'About us' }),
+      head() {
+        return {
+          title: pageTitle(this.title),
+          meta: [
+            { name: 'description', content: this.description },
+            { property: 'og:title', content: pageTitle(this.title) }
+          ]
+        }
+      },
+      template: '<div />'
+    }
+
+    const wrapper = mountWithHead(Comp)
+    await flushPromises()
+    await renderHead()
+
+    expect(document.title).toBe(`About · ${SITE_NAME}`)
+    expect(document.querySelector('meta[name="description"]')?.content).toBe('About us')
+    expect(document.querySelector('meta[property="og:title"]')?.content).toBe(
+      `About · ${SITE_NAME}`
+    )
+
+    // Reactivity: changing state updates the rendered tags.
+    wrapper.vm.title = 'Jobs'
+    wrapper.vm.description = 'Job openings'
+    await flushPromises()
+    await renderHead()
+
+    expect(document.title).toBe(`Jobs · ${SITE_NAME}`)
+    expect(document.querySelector('meta[name="description"]')?.content).toBe('Job openings')
+  })
+})

--- a/src/components/jobs/JobListing.vue
+++ b/src/components/jobs/JobListing.vue
@@ -24,11 +24,29 @@
 <script>
 import { defineComponent } from 'vue'
 import DOMPurify from 'dompurify'
+import { SITE_NAME } from '@/seo'
 
 export default defineComponent({
   name: 'JobView',
   props: {},
   components: [],
+  // Per-job document head, overriding App.vue's generic "Job Listing" title
+  // once the job has loaded so each listing has a distinct, indexable title
+  // and description.
+  head() {
+    if (!this.job?.title) return {}
+    const label = this.job.company ? `${this.job.title} at ${this.job.company}` : this.job.title
+    const title = `${label} · ${SITE_NAME}`
+    const description = this.plainDescription
+    return {
+      title,
+      meta: [
+        { name: 'description', content: description },
+        { property: 'og:title', content: title },
+        { property: 'og:description', content: description }
+      ]
+    }
+  },
   data() {
     return {
       job: {
@@ -77,6 +95,15 @@ export default defineComponent({
     },
     sanitizedDescription() {
       return DOMPurify.sanitize(this.job.description)
+    },
+    // Plain-text, length-capped version of the description for use as the meta
+    // description / OG description (search + social snippets).
+    plainDescription() {
+      const text = DOMPurify.sanitize(this.job.description, { ALLOWED_TAGS: [] })
+        .replace(/\s+/g, ' ')
+        .trim()
+      if (!text) return `${this.job.title} at ${this.job.company} — apply via IndyHackers.`
+      return text.length > 160 ? `${text.slice(0, 157).trimEnd()}…` : text
     },
     sanitizedHowToApply() {
       return DOMPurify.sanitize(this.job.how_to_apply)

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,7 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
+import { createHead } from '@unhead/vue/client'
+import { VueHeadMixin } from '@unhead/vue'
 import { createBootstrap } from 'bootstrap-vue-next'
 //import { BVToastPlugin } from 'bootstrap-vue'
 //import { jQuery } from 'jQuery'
@@ -29,6 +31,7 @@ const emitter = mitt()
 //const toaster = useToast()
 
 const app = createApp(App)
+const head = createHead()
 app.config.globalProperties.pocketbase = pocketbase
 app.config.globalProperties.emitter = emitter
 app.provide('pocketbase', pocketbase)
@@ -38,6 +41,10 @@ app.provide('emitter', emitter)
 
 //window.jQuery = jQuery
 
+app.use(head)
+// Enables the Options-API `head()` component option (reactive) alongside the
+// `useHead()` composable — used by App.vue for route-driven meta.
+app.mixin(VueHeadMixin)
 app.use(createPinia())
 app.use(createBootstrap())
 //app.use(BVToastPlugin)

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -12,17 +12,27 @@ const router = createRouter({
       name: 'Home',
       component: HomeView,
       props: { title: 'Home', content: 'Welcome to IndyHackers.' }
+      // No meta.title → uses the default site title ("IndyHackers — Indiana's
+      // Tech Community") and the default description.
     },
     {
       path: '/jobs',
       name: 'Jobs',
       component: () => import('../views/OmniView.vue'),
-      props: { currentComponent: 'JobsList' }
+      props: { currentComponent: 'JobsList' },
+      meta: {
+        title: 'Tech Jobs in Indianapolis',
+        description:
+          'Browse developer and tech job openings from Indianapolis-area companies, posted to the IndyHackers community.'
+      }
     },
     {
       path: '/job',
       component: () => import('../views/OmniView.vue'),
-      props: { currentComponent: 'JobListing' }
+      props: { currentComponent: 'JobListing' },
+      // A single job listing; JobListing.vue overrides title/description with
+      // the specific job once it loads.
+      meta: { title: 'Job Listing' }
     },
     {
       path: '/jobs-markdown',
@@ -37,44 +47,85 @@ const router = createRouter({
     {
       path: '/about',
       name: 'About',
-      component: () => import('../views/AboutView.vue')
+      component: () => import('../views/AboutView.vue'),
+      meta: {
+        title: 'About',
+        description:
+          "Learn about IndyHackers — Indiana's tech community since 2017: our meetups, our mission, and how to get involved."
+      }
     },
     {
       path: '/privacy',
       name: 'Privacy',
       component: () => import('../views/PlaceholderView.vue'),
-      props: { title: 'Privacy Policy', content: 'Our privacy policy.' }
+      props: { title: 'Privacy Policy', content: 'Our privacy policy.' },
+      meta: {
+        title: 'Privacy Policy',
+        description: 'How IndyHackers collects, uses, and protects your data.'
+      }
     },
     {
       path: '/terms',
       name: 'Terms',
       component: () => import('../views/PlaceholderView.vue'),
-      props: { title: 'Terms of Service', content: 'Our terms of service.' }
+      props: { title: 'Terms of Service', content: 'Our terms of service.' },
+      meta: {
+        title: 'Terms of Service',
+        description: 'The terms of service for using the IndyHackers website and community.'
+      }
     },
     {
       path: '/support',
       name: 'Support',
       component: () => import('../views/PlaceholderView.vue'),
-      props: { title: 'Support', content: 'Get support.' }
+      props: { title: 'Support', content: 'Get support.' },
+      meta: {
+        title: 'Support',
+        description: 'Get help with the IndyHackers website, events, job board, and Slack.'
+      }
     },
     { path: '/admin', name: 'Admin', component: () => import('../components/AdminLogin.vue') },
     { path: '/login', name: 'Login', component: () => import('../components/LoginPage.vue') },
     { path: '/signup', name: 'Signup', component: () => import('../components/SignupPage.vue') },
-    { path: '/sponsors', name: 'Sponsors', component: () => import('../views/SponsorsView.vue') },
+    {
+      path: '/sponsors',
+      name: 'Sponsors',
+      component: () => import('../views/SponsorsView.vue'),
+      meta: {
+        title: 'Sponsors',
+        description:
+          'Meet the companies sponsoring IndyHackers and supporting the Indianapolis tech community.'
+      }
+    },
     {
       path: '/newsletter',
       name: 'Newsletter',
-      component: () => import('../components/NewsletterView.vue')
+      component: () => import('../components/NewsletterView.vue'),
+      meta: {
+        title: 'Newsletter — Hacks & Happenings',
+        description:
+          'Hacks & Happenings: an occasional roundup of local developer projects, blog posts, and Indianapolis tech events, delivered to your inbox.'
+      }
     },
     {
       path: '/recommend-event',
       name: 'RecommendEvent',
-      component: () => import('../components/EventRecommendationForm.vue')
+      component: () => import('../components/EventRecommendationForm.vue'),
+      meta: {
+        title: 'Recommend an Event',
+        description:
+          'Suggest a tech event, meetup, or workshop for the IndyHackers community calendar.'
+      }
     },
     {
       path: '/calendar',
       name: 'Calendar',
-      component: () => import('../components/CalendarView.vue')
+      component: () => import('../components/CalendarView.vue'),
+      meta: {
+        title: 'Tech Events in Indianapolis',
+        description:
+          'Upcoming tech meetups, workshops, and developer events around Indianapolis.'
+      }
     },
     { path: '/events', redirect: '/calendar' },
     {
@@ -85,7 +136,11 @@ const router = createRouter({
     {
       path: '/code-of-conduct',
       name: 'CodeOfConduct',
-      component: () => import('../components/CodeOfConduct.vue')
+      component: () => import('../components/CodeOfConduct.vue'),
+      meta: {
+        title: 'Code of Conduct',
+        description: 'The code of conduct for the IndyHackers community, events, and Slack.'
+      }
     }
   ]
 })

--- a/src/seo.js
+++ b/src/seo.js
@@ -1,0 +1,28 @@
+// Shared SEO constants. Kept in one place so canonical/OG URLs, the sitemap
+// generator, and structured data all agree on the site's identity.
+
+export const SITE_URL = 'https://www.indyhackers.org'
+export const SITE_NAME = 'IndyHackers'
+export const SITE_TAGLINE = "Indiana's Tech Community"
+
+// Used as the <title> on the homepage and as a fallback everywhere a page
+// doesn't set its own title.
+export const DEFAULT_TITLE = `${SITE_NAME} — ${SITE_TAGLINE}`
+
+export const DEFAULT_DESCRIPTION =
+  "IndyHackers is Indianapolis's tech community — 3,000+ members, meetups, jobs, and a Slack where Indy devs hang out."
+
+// Absolute URL to the default social-share image (the homepage hero).
+export const DEFAULT_OG_IMAGE = `${SITE_URL}/images/welcome.webp`
+
+// Build a page title of the form "Page · IndyHackers", falling back to the
+// full default title when a page has no title of its own.
+export function pageTitle(title) {
+  return title ? `${title} · ${SITE_NAME}` : DEFAULT_TITLE
+}
+
+// Absolute canonical URL for a router path (drops any query string / hash).
+export function canonicalUrl(path) {
+  const clean = (path || '/').split('?')[0].split('#')[0]
+  return SITE_URL + clean
+}


### PR DESCRIPTION
## Part 1 of 4 — SEO improvements

Foundational PR of a stacked series. Adds [`@unhead/vue`](https://unhead.unjs.io/) and gives every route its own document head.

### Problem
The site is a client-rendered SPA whose `index.html` sets a single `<title>` and `<meta name="description">` for **every** route. So `/jobs`, `/about`, `/newsletter`, etc. all look like duplicates of the homepage to search engines, and pasting any URL into Slack/LinkedIn/Discord yields no title, description, or image.

### Changes
- **`src/seo.js`** — shared `SITE_URL` / `SITE_NAME` / defaults + `pageTitle()` and `canonicalUrl()` helpers (reused by later PRs and the sitemap).
- **`main.js`** — install `createHead()` + `VueHeadMixin` (enables the Options-API `head()` option).
- **`App.vue`** — site-wide, `$route`-driven `head()`: `<title>`, `rel=canonical`, and full Open Graph + Twitter Card tags, all reactive to navigation.
- **`router/index.js`** — per-route `meta.title` / `meta.description` for indexable public routes (home falls back to the default site title).
- **`JobListing.vue`** — dynamic per-job title + description so each listing is distinct and indexable.
- **Tests** — `src/__tests__/seo.spec.js`: helper coverage + an end-to-end check that the unhead `head()` wiring renders to the document and reacts to state changes.

### Verification
- `npm run build` ✓
- New SEO tests pass; existing suites unaffected (the 3 pre-existing failures — HelloWorld/LoginPage/SignupPage — also fail on `dev`, unrelated to this PR).

### Note on `package-lock.json`
Regenerated by `npm install @unhead/vue`. The committed lock had drifted from `package.json` (missing ~136 transitive entries), so npm normalized it; `vue` resolved 3.4.36 → 3.5.39 within its existing `^3.4.29` range as a side effect.

### Follow-ups (stacked on this branch)
2. JSON-LD structured data (Organization / JobPosting / Event)
3. `vite-ssg` prerendering
4. sitemap.xml + robots.txt + `noindex` on admin/utility routes + flesh out placeholder pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)