### PR TITLE
SEO 2/4: JSON-LD structured data

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -16,6 +16,8 @@ import {
   SITE_NAME,
   DEFAULT_DESCRIPTION,
   DEFAULT_OG_IMAGE,
+  ORGANIZATION_SCHEMA,
+  jsonLd,
   pageTitle,
   canonicalUrl
 } from '@/seo'
@@ -51,7 +53,9 @@ export default {
         { name: 'twitter:title', content: title },
         { name: 'twitter:description', content: description },
         { name: 'twitter:image', content: DEFAULT_OG_IMAGE }
-      ]
+      ],
+      // Site-wide Organization structured data.
+      script: [jsonLd(ORGANIZATION_SCHEMA, 'ld-organization')]
     }
   },
   computed: {

--- a/src/__tests__/seo.spec.js
+++ b/src/__tests__/seo.spec.js
@@ -1,8 +1,18 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createHead, renderDOMHead } from '@unhead/vue/client'
 import { VueHeadMixin } from '@unhead/vue'
-import { SITE_URL, SITE_NAME, DEFAULT_TITLE, pageTitle, canonicalUrl } from '@/seo'
+import JobListing from '@/components/jobs/JobListing.vue'
+import {
+  SITE_URL,
+  SITE_NAME,
+  DEFAULT_TITLE,
+  pageTitle,
+  canonicalUrl,
+  jsonLd,
+  stripHtml,
+  ORGANIZATION_SCHEMA
+} from '@/seo'
 
 describe('seo helpers', () => {
   it('pageTitle suffixes the site name, falling back to the default title', () => {
@@ -16,6 +26,31 @@ describe('seo helpers', () => {
     expect(canonicalUrl('/job?id=abc')).toBe(`${SITE_URL}/job`)
     expect(canonicalUrl('/x#frag')).toBe(`${SITE_URL}/x`)
     expect(canonicalUrl(undefined)).toBe(`${SITE_URL}/`)
+  })
+
+  it('stripHtml removes tags, collapses whitespace, and caps length', () => {
+    expect(stripHtml('<p>Hello   <b>world</b></p>')).toBe('Hello world')
+    expect(stripHtml('')).toBe('')
+    const long = stripHtml('x'.repeat(400), 10)
+    expect(long.length).toBe(10)
+    expect(long.endsWith('…')).toBe(true)
+  })
+
+  it('jsonLd produces an ld+json descriptor and escapes < for safety', () => {
+    const tag = jsonLd({ '@type': 'Thing', name: '</script><b>' }, 'ld-x')
+    expect(tag.type).toBe('application/ld+json')
+    expect(tag.key).toBe('ld-x')
+    expect(tag.innerHTML).not.toContain('</script>')
+    expect(tag.innerHTML).toContain('\\u003c')
+    // Round-trips back to the original object (the escape is JSON-safe).
+    expect(JSON.parse(tag.innerHTML).name).toBe('</script><b>')
+  })
+
+  it('ORGANIZATION_SCHEMA is valid schema.org Organization markup', () => {
+    expect(ORGANIZATION_SCHEMA['@context']).toBe('https://schema.org')
+    expect(ORGANIZATION_SCHEMA['@type']).toBe('Organization')
+    expect(ORGANIZATION_SCHEMA.name).toBe(SITE_NAME)
+    expect(ORGANIZATION_SCHEMA.url).toBe(SITE_URL)
   })
 })
 
@@ -69,5 +104,46 @@ describe('unhead head() wiring', () => {
 
     expect(document.title).toBe(`Jobs · ${SITE_NAME}`)
     expect(document.querySelector('meta[name="description"]')?.content).toBe('Job openings')
+  })
+
+  it('JobListing emits valid JobPosting JSON-LD once the job loads', async () => {
+    head = createHead()
+    const job = {
+      id: 'job1',
+      title: 'Senior Developer',
+      company: 'Acme Corp',
+      salary_min: 100,
+      salary_max: 150,
+      description: '<p>Great <strong>opportunity</strong></p>',
+      how_to_apply: '',
+      created: '2025-01-10T12:00:00.000Z',
+      approved_at: '2025-01-15T12:00:00.000Z'
+    }
+    const pb = { collection: () => ({ getOne: vi.fn().mockResolvedValue(job) }) }
+
+    mount(JobListing, {
+      global: {
+        plugins: [head],
+        mixins: [VueHeadMixin],
+        config: { globalProperties: { pocketbase: pb, $route: { query: { id: 'job1' } } } },
+        stubs: {
+          'b-card': { template: '<div><slot /></div>' },
+          'b-badge': { template: '<span><slot /></span>' }
+        }
+      }
+    })
+    await flushPromises()
+    await renderHead()
+
+    const tag = document.querySelector('script[type="application/ld+json"]')
+    expect(tag).toBeTruthy()
+    const data = JSON.parse(tag.textContent)
+    expect(data['@type']).toBe('JobPosting')
+    expect(data.title).toBe('Senior Developer')
+    expect(data.hiringOrganization.name).toBe('Acme Corp')
+    expect(data.datePosted).toBe('2025-01-15')
+    expect(data.baseSalary.value.minValue).toBe(100000)
+    expect(data.baseSalary.value.maxValue).toBe(150000)
+    expect(data.jobLocation.address.addressRegion).toBe('IN')
   })
 })

--- a/src/components/EventsView.vue
+++ b/src/components/EventsView.vue
@@ -56,9 +56,11 @@
 </template>
 
 <script setup>
-import { onMounted } from 'vue'
+import { computed, onMounted } from 'vue'
+import { useHead } from '@unhead/vue'
 import { BAlert, BSpinner } from 'bootstrap-vue-next'
 import { useCalendar } from '@/composables/useCalendar'
+import { jsonLd, stripHtml, SITE_NAME, SITE_URL } from '@/seo'
 import EventListItem from '@/components/EventListItem.vue'
 
 const props = defineProps({
@@ -69,6 +71,40 @@ const props = defineProps({
 })
 
 const { events, loading, error, fetchEvents, visibleEvents, hasMore, loadMore } = useCalendar({ initialCount: props.limit })
+
+// Event structured data for the upcoming events shown here → eligible for
+// Google's event rich results. Rebuilds reactively as events load.
+const eventsSchema = computed(() =>
+  visibleEvents.value
+    .filter((e) => e.title && e.start)
+    .map((e) => {
+      const node = {
+        '@context': 'https://schema.org',
+        '@type': 'Event',
+        name: e.title,
+        startDate: e.start,
+        eventStatus: 'https://schema.org/EventScheduled',
+        organizer: { '@type': 'Organization', name: SITE_NAME, url: SITE_URL }
+      }
+      if (e.end) node.endDate = e.end
+      if (e.description) node.description = stripHtml(e.description)
+      if (e.link) node.url = e.link
+      if (e.location) {
+        node.eventAttendanceMode = 'https://schema.org/OfflineEventAttendanceMode'
+        node.location = { '@type': 'Place', name: e.location, address: e.location }
+      } else {
+        node.eventAttendanceMode = 'https://schema.org/OnlineEventAttendanceMode'
+        node.location = { '@type': 'VirtualLocation', url: e.link || SITE_URL }
+      }
+      return node
+    })
+)
+
+useHead(
+  computed(() => ({
+    script: eventsSchema.value.length ? [jsonLd(eventsSchema.value, 'ld-events')] : []
+  }))
+)
 
 onMounted(() => {
   fetchEvents()

--- a/src/components/jobs/JobListing.vue
+++ b/src/components/jobs/JobListing.vue
@@ -24,7 +24,7 @@
 <script>
 import { defineComponent } from 'vue'
 import DOMPurify from 'dompurify'
-import { SITE_NAME } from '@/seo'
+import { SITE_NAME, jsonLd } from '@/seo'
 
 export default defineComponent({
   name: 'JobView',
@@ -44,7 +44,9 @@ export default defineComponent({
         { name: 'description', content: description },
         { property: 'og:title', content: title },
         { property: 'og:description', content: description }
-      ]
+      ],
+      // JobPosting structured data → eligible for the Google Jobs rich result.
+      script: [jsonLd(this.jobPostingSchema, 'ld-jobposting')]
     }
   },
   data() {
@@ -104,6 +106,56 @@ export default defineComponent({
         .trim()
       if (!text) return `${this.job.title} at ${this.job.company} — apply via IndyHackers.`
       return text.length > 160 ? `${text.slice(0, 157).trimEnd()}…` : text
+    },
+    // ISO date (YYYY-MM-DD) the posting went live — required by Google for
+    // JobPosting. Falls back to the created date if not yet approved.
+    datePostedIso() {
+      const raw = this.job.approved_at || this.job.created
+      if (!raw) return undefined
+      const date = new Date(raw)
+      return isNaN(date.getTime()) ? undefined : date.toISOString().slice(0, 10)
+    },
+    // schema.org MonetaryAmount for the salary range, or null when unknown.
+    // Stored values are in thousands of USD/year.
+    baseSalarySchema() {
+      const { salary_min: min, salary_max: max } = this.job
+      if (!min && !max) return null
+      const value = { '@type': 'QuantitativeValue', unitText: 'YEAR' }
+      if (min) value.minValue = min * 1000
+      if (max) value.maxValue = max * 1000
+      if (min && !max) value.value = min * 1000
+      if (max && !min) value.value = max * 1000
+      return { '@type': 'MonetaryAmount', currency: 'USD', value }
+    },
+    // JobPosting structured data for this listing. schema.org allows HTML in
+    // `description`, and Google recommends the full (sanitized) description.
+    jobPostingSchema() {
+      const job = this.job
+      if (!job?.title) return null
+      const schema = {
+        '@context': 'https://schema.org',
+        '@type': 'JobPosting',
+        title: job.title,
+        description: this.sanitizedDescription || job.title,
+        hiringOrganization: {
+          '@type': 'Organization',
+          name: job.company || SITE_NAME
+        },
+        // The board serves the Indianapolis area; used as the default location
+        // since listings don't carry a per-job location field.
+        jobLocation: {
+          '@type': 'Place',
+          address: {
+            '@type': 'PostalAddress',
+            addressLocality: 'Indianapolis',
+            addressRegion: 'IN',
+            addressCountry: 'US'
+          }
+        }
+      }
+      if (this.datePostedIso) schema.datePosted = this.datePostedIso
+      if (this.baseSalarySchema) schema.baseSalary = this.baseSalarySchema
+      return schema
     },
     sanitizedHowToApply() {
       return DOMPurify.sanitize(this.job.how_to_apply)

--- a/src/seo.js
+++ b/src/seo.js
@@ -26,3 +26,34 @@ export function canonicalUrl(path) {
   const clean = (path || '/').split('?')[0].split('#')[0]
   return SITE_URL + clean
 }
+
+// Wrap a schema.org object (or array of them) as an unhead
+// <script type="application/ld+json"> descriptor. `key` lets unhead dedupe and
+// update the tag across re-renders. `<` is escaped so the JSON can never break
+// out of the surrounding <script> element (JSON-LD best practice).
+export function jsonLd(schema, key) {
+  return {
+    type: 'application/ld+json',
+    key,
+    innerHTML: JSON.stringify(schema).replace(/</g, '\\u003c')
+  }
+}
+
+// Strip HTML to plain text and cap its length — for JSON-LD / meta text fields.
+export function stripHtml(html, max = 300) {
+  const text = String(html || '')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return max && text.length > max ? `${text.slice(0, max - 1).trimEnd()}…` : text
+}
+
+// Site-wide Organization markup, rendered on every page via App.vue.
+export const ORGANIZATION_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: SITE_NAME,
+  url: SITE_URL,
+  logo: `${SITE_URL}/favicon.png`,
+  description: DEFAULT_DESCRIPTION
+}


### PR DESCRIPTION
## Part 2 of 4 — SEO improvements

Stacked on #68. **Base this on `pr1-seo-meta-unhead`; retarget to `dev` once #68 merges.**

Adds schema.org structured data (JSON-LD) so pages become eligible for Google rich results.

### Changes
- **Organization** — site-wide on every page (via `App.vue`).
- **JobPosting** — per job listing (`JobListing.vue`) → eligible for the **Google Jobs** rich result. Includes `title`, `description` (sanitized HTML, as Google recommends), `hiringOrganization`, `datePosted`, and `baseSalary` derived from the K-denominated salary fields. `jobLocation` defaults to Indianapolis, IN since listings carry no per-job location field (noted in code — wire a real field through here if one is added).
- **Event** — upcoming events on the homepage (`EventsView.vue`) → eligible for event rich results; built reactively from the Google Calendar feed, with offline/virtual location handling.
- **`seo.js`** helpers — `jsonLd()` (wraps a schema as an `ld+json` script and escapes `<` so content can't break out of the element), `stripHtml()`, and `ORGANIZATION_SCHEMA`.

### Verification
- `npm run build` ✓, lint clean.
- Tests: helper coverage (incl. `<`-escape round-trip) + an end-to-end check that `JobListing` emits valid `JobPosting` JSON-LD once the job loads. Existing suites unaffected.

### Validating the output
After merge/deploy, run representative URLs through Google's [Rich Results Test](https://search.google.com/test/rich-results) to confirm JobPosting/Event eligibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)