### PR TITLE
SEO 3/4: prerender static routes (vite-ssg)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Build the image from source only — deps are installed and the app is built
+# fresh inside the image. Keeping the context small speeds up the build and
+# avoids copying local/dev artifacts (and secrets) into it.
+.git
+node_modules
+dist
+dist-ssr
+.vite-ssg-temp
+
+# Local database + test/tooling output
+pb/data
+coverage
+test-results
+playwright-report
+
+# Env files and logs — never bake secrets into the image
+.env
+.env.*
+!.env.example
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules
 .DS_Store
 dist
 dist-ssr
+.vite-ssg-temp
 coverage
 *.local
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ RUN wget https://github.com/pocketbase/pocketbase/releases/download/v${PB_VERSIO
 
 # --------
 
-FROM node:21 as vue-builder
+# Node 22+ is required: the vite-ssg build pulls in a jsdom dependency
+# (@exodus/bytes) that is ESM-only and cannot be require()'d on Node 21.
+FROM node:24 as vue-builder
 
 WORKDIR /app/ui
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,8 +46,16 @@
         "unplugin-vue-components": "^0.27.4",
         "vite": "^6.3.5",
         "vite-plugin-vue-devtools": "^v8.0.3",
+        "vite-ssg": "^28.3.0",
         "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@antfu/install-pkg": {
       "version": "0.5.0",
@@ -70,6 +78,64 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -566,6 +632,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@bundled-es-modules/cookie": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@bundled-es-modules/cookie/-/cookie-2.0.1.tgz",
@@ -593,6 +672,146 @@
       "dependencies": {
         "@types/tough-cookie": "^4.0.5",
         "tough-cookie": "^4.1.4"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1067,6 +1286,24 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.5.tgz",
@@ -1396,7 +1633,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1418,10 +1655,21 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -1434,7 +1682,7 @@
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2868,7 +3116,7 @@
       "version": "8.17.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -2887,13 +3135,11 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -3031,6 +3277,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3159,6 +3415,13 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/bundle-name": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -3206,6 +3469,17 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/camel-case": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pascal-case": "^3.1.2",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/caniuse-lite": {
@@ -3306,6 +3580,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/clean-css": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 10.0"
       }
     },
     "node_modules/cli-width": {
@@ -3483,6 +3770,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3551,10 +3852,11 @@
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
-      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
-      "dev": true
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -3643,6 +3945,17 @@
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/dot-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/dunder-proto": {
@@ -4525,6 +4838,38 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-minifier-terser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
+      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "camel-case": "^4.1.2",
+        "clean-css": "~5.3.2",
+        "commander": "^10.0.0",
+        "entities": "^4.4.0",
+        "param-case": "^3.0.4",
+        "relateurl": "^0.2.7",
+        "terser": "^5.15.1"
+      },
+      "bin": {
+        "html-minifier-terser": "cli.js"
+      },
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/html5parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html5parser/-/html5parser-2.0.2.tgz",
+      "integrity": "sha512-L0y+IdTVxHsovmye8MBtFgBvWZnq1C9WnI/SmJszxoQjmUH1psX2uzDk21O5k5et6udxdGjwxkbmT9eVRoG05w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.2.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4539,12 +4884,13 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -5039,6 +5385,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lower-case": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -5090,6 +5446,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mdurl": {
       "version": "2.0.0",
@@ -5297,6 +5660,17 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
+    "node_modules/no-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lower-case": "^2.0.2",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.50",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
@@ -5461,6 +5835,17 @@
       "integrity": "sha512-ts9KSdroZisdvKMWVAVCXiKqnqNfXz4+IbrBG8/BWx/TR5le+jfenvoBuIZ6UWM9nz47W7AbD9qYfAwfWMIwzA==",
       "dev": true
     },
+    "node_modules/param-case": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dot-case": "^3.0.4",
+        "tslib": "^2.0.3"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -5483,6 +5868,17 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pascal-case": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "no-case": "^3.0.4",
+        "tslib": "^2.0.3"
       }
     },
     "node_modules/path-exists": {
@@ -5996,11 +6392,31 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6276,12 +6692,33 @@
         "node": ">=18"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/speakingurl": {
@@ -6492,6 +6929,32 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/terser": {
+      "version": "5.48.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
+      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.15.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -6596,6 +7059,26 @@
         "@popperjs/core": "^2.9.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.5.tgz",
+      "integrity": "sha512-RfEzKWcq5fHUOFq7J3rl3Oz6ylKGtcHqUznzj4EcXsxLSIjJcvpbXAQtWGeJQ0xKnimR5e0Cn+cn9TssfMzm+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.5"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.5.tgz",
+      "integrity": "sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6686,6 +7169,16 @@
       "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/unhead": {
       "version": "2.1.15",
@@ -7145,6 +7638,253 @@
       },
       "peerDependencies": {
         "vite": "^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0"
+      }
+    },
+    "node_modules/vite-ssg": {
+      "version": "28.3.0",
+      "resolved": "https://registry.npmjs.org/vite-ssg/-/vite-ssg-28.3.0.tgz",
+      "integrity": "sha512-dIUjv+scfhJTfYGwf83R0KGAmr/duIo9oln5ZsQOIZZACm3voAON//7oKhtEwaOTtD4QTTab+nhvyn0QiIaFMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@unhead/dom": "^2.1.2",
+        "@unhead/vue": "^2.1.2",
+        "ansis": "^4.2.0",
+        "cac": "^6.7.14",
+        "html-minifier-terser": "^7.2.0",
+        "html5parser": "^2.0.2",
+        "jsdom": "^28.0.0"
+      },
+      "bin": {
+        "vite-ssg": "bin/vite-ssg.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "beasties": "^0.3.5",
+        "prettier": "^3.3.0",
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0-0 || ^8.0.0-0",
+        "vue": "^3.2.10",
+        "vue-router": "^4.0.1 || ^5.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "beasties": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-ssg/node_modules/@unhead/dom": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/@unhead/dom/-/dom-2.1.15.tgz",
+      "integrity": "sha512-3/qtu2uOVW0eyYCIljweQ9sRDiFpCasGv9A7LjbcqWR9cxEPDYiJBiK2lVqPJT68qonAeXhtiS08PTCWTau8SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "unhead": "2.1.15"
+      }
+    },
+    "node_modules/vite-ssg/node_modules/cssstyle": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/vite-ssg/node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/vite-ssg/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/vite-ssg/node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/vite-ssg/node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-ssg/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/vite-ssg/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/vite-ssg/node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/vite-ssg/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/vite-ssg/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/vite-ssg/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/vite-ssg/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/vite-ssg/node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/vite/node_modules/fdir": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "vite-ssg build",
+    "build:spa": "vite build",
     "preview": "vite preview",
     "test:unit": "vitest",
     "test:e2e": "playwright test",
@@ -52,6 +53,7 @@
     "unplugin-vue-components": "^0.27.4",
     "vite": "^6.3.5",
     "vite-plugin-vue-devtools": "^v8.0.3",
+    "vite-ssg": "^28.3.0",
     "vitest": "^3.2.4"
   },
   "msw": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,6 +16,8 @@ import {
   SITE_NAME,
   DEFAULT_DESCRIPTION,
   DEFAULT_OG_IMAGE,
+  ORGANIZATION_SCHEMA,
+  jsonLd,
   pageTitle,
   canonicalUrl
 } from '@/seo'
@@ -51,7 +53,9 @@ export default {
         { name: 'twitter:title', content: title },
         { name: 'twitter:description', content: description },
         { name: 'twitter:image', content: DEFAULT_OG_IMAGE }
-      ]
+      ],
+      // Site-wide Organization structured data.
+      script: [jsonLd(ORGANIZATION_SCHEMA, 'ld-organization')]
     }
   },
   computed: {

--- a/src/__tests__/seo.spec.js
+++ b/src/__tests__/seo.spec.js
@@ -1,8 +1,18 @@
-import { describe, it, expect, afterEach } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createHead, renderDOMHead } from '@unhead/vue/client'
 import { VueHeadMixin } from '@unhead/vue'
-import { SITE_URL, SITE_NAME, DEFAULT_TITLE, pageTitle, canonicalUrl } from '@/seo'
+import JobListing from '@/components/jobs/JobListing.vue'
+import {
+  SITE_URL,
+  SITE_NAME,
+  DEFAULT_TITLE,
+  pageTitle,
+  canonicalUrl,
+  jsonLd,
+  stripHtml,
+  ORGANIZATION_SCHEMA
+} from '@/seo'
 
 describe('seo helpers', () => {
   it('pageTitle suffixes the site name, falling back to the default title', () => {
@@ -16,6 +26,31 @@ describe('seo helpers', () => {
     expect(canonicalUrl('/job?id=abc')).toBe(`${SITE_URL}/job`)
     expect(canonicalUrl('/x#frag')).toBe(`${SITE_URL}/x`)
     expect(canonicalUrl(undefined)).toBe(`${SITE_URL}/`)
+  })
+
+  it('stripHtml removes tags, collapses whitespace, and caps length', () => {
+    expect(stripHtml('<p>Hello   <b>world</b></p>')).toBe('Hello world')
+    expect(stripHtml('')).toBe('')
+    const long = stripHtml('x'.repeat(400), 10)
+    expect(long.length).toBe(10)
+    expect(long.endsWith('…')).toBe(true)
+  })
+
+  it('jsonLd produces an ld+json descriptor and escapes < for safety', () => {
+    const tag = jsonLd({ '@type': 'Thing', name: '</script><b>' }, 'ld-x')
+    expect(tag.type).toBe('application/ld+json')
+    expect(tag.key).toBe('ld-x')
+    expect(tag.innerHTML).not.toContain('</script>')
+    expect(tag.innerHTML).toContain('\\u003c')
+    // Round-trips back to the original object (the escape is JSON-safe).
+    expect(JSON.parse(tag.innerHTML).name).toBe('</script><b>')
+  })
+
+  it('ORGANIZATION_SCHEMA is valid schema.org Organization markup', () => {
+    expect(ORGANIZATION_SCHEMA['@context']).toBe('https://schema.org')
+    expect(ORGANIZATION_SCHEMA['@type']).toBe('Organization')
+    expect(ORGANIZATION_SCHEMA.name).toBe(SITE_NAME)
+    expect(ORGANIZATION_SCHEMA.url).toBe(SITE_URL)
   })
 })
 
@@ -69,5 +104,46 @@ describe('unhead head() wiring', () => {
 
     expect(document.title).toBe(`Jobs · ${SITE_NAME}`)
     expect(document.querySelector('meta[name="description"]')?.content).toBe('Job openings')
+  })
+
+  it('JobListing emits valid JobPosting JSON-LD once the job loads', async () => {
+    head = createHead()
+    const job = {
+      id: 'job1',
+      title: 'Senior Developer',
+      company: 'Acme Corp',
+      salary_min: 100,
+      salary_max: 150,
+      description: '<p>Great <strong>opportunity</strong></p>',
+      how_to_apply: '',
+      created: '2025-01-10T12:00:00.000Z',
+      approved_at: '2025-01-15T12:00:00.000Z'
+    }
+    const pb = { collection: () => ({ getOne: vi.fn().mockResolvedValue(job) }) }
+
+    mount(JobListing, {
+      global: {
+        plugins: [head],
+        mixins: [VueHeadMixin],
+        config: { globalProperties: { pocketbase: pb, $route: { query: { id: 'job1' } } } },
+        stubs: {
+          'b-card': { template: '<div><slot /></div>' },
+          'b-badge': { template: '<span><slot /></span>' }
+        }
+      }
+    })
+    await flushPromises()
+    await renderHead()
+
+    const tag = document.querySelector('script[type="application/ld+json"]')
+    expect(tag).toBeTruthy()
+    const data = JSON.parse(tag.textContent)
+    expect(data['@type']).toBe('JobPosting')
+    expect(data.title).toBe('Senior Developer')
+    expect(data.hiringOrganization.name).toBe('Acme Corp')
+    expect(data.datePosted).toBe('2025-01-15')
+    expect(data.baseSalary.value.minValue).toBe(100000)
+    expect(data.baseSalary.value.maxValue).toBe(150000)
+    expect(data.jobLocation.address.addressRegion).toBe('IN')
   })
 })

--- a/src/components/EventsView.vue
+++ b/src/components/EventsView.vue
@@ -56,9 +56,11 @@
 </template>
 
 <script setup>
-import { onMounted } from 'vue'
+import { computed, onMounted } from 'vue'
+import { useHead } from '@unhead/vue'
 import { BAlert, BSpinner } from 'bootstrap-vue-next'
 import { useCalendar } from '@/composables/useCalendar'
+import { jsonLd, stripHtml, SITE_NAME, SITE_URL } from '@/seo'
 import EventListItem from '@/components/EventListItem.vue'
 
 const props = defineProps({
@@ -69,6 +71,40 @@ const props = defineProps({
 })
 
 const { events, loading, error, fetchEvents, visibleEvents, hasMore, loadMore } = useCalendar({ initialCount: props.limit })
+
+// Event structured data for the upcoming events shown here → eligible for
+// Google's event rich results. Rebuilds reactively as events load.
+const eventsSchema = computed(() =>
+  visibleEvents.value
+    .filter((e) => e.title && e.start)
+    .map((e) => {
+      const node = {
+        '@context': 'https://schema.org',
+        '@type': 'Event',
+        name: e.title,
+        startDate: e.start,
+        eventStatus: 'https://schema.org/EventScheduled',
+        organizer: { '@type': 'Organization', name: SITE_NAME, url: SITE_URL }
+      }
+      if (e.end) node.endDate = e.end
+      if (e.description) node.description = stripHtml(e.description)
+      if (e.link) node.url = e.link
+      if (e.location) {
+        node.eventAttendanceMode = 'https://schema.org/OfflineEventAttendanceMode'
+        node.location = { '@type': 'Place', name: e.location, address: e.location }
+      } else {
+        node.eventAttendanceMode = 'https://schema.org/OnlineEventAttendanceMode'
+        node.location = { '@type': 'VirtualLocation', url: e.link || SITE_URL }
+      }
+      return node
+    })
+)
+
+useHead(
+  computed(() => ({
+    script: eventsSchema.value.length ? [jsonLd(eventsSchema.value, 'ld-events')] : []
+  }))
+)
 
 onMounted(() => {
   fetchEvents()

--- a/src/components/jobs/JobListing.vue
+++ b/src/components/jobs/JobListing.vue
@@ -24,7 +24,7 @@
 <script>
 import { defineComponent } from 'vue'
 import DOMPurify from 'dompurify'
-import { SITE_NAME } from '@/seo'
+import { SITE_NAME, jsonLd } from '@/seo'
 
 export default defineComponent({
   name: 'JobView',
@@ -44,7 +44,9 @@ export default defineComponent({
         { name: 'description', content: description },
         { property: 'og:title', content: title },
         { property: 'og:description', content: description }
-      ]
+      ],
+      // JobPosting structured data → eligible for the Google Jobs rich result.
+      script: [jsonLd(this.jobPostingSchema, 'ld-jobposting')]
     }
   },
   data() {
@@ -104,6 +106,56 @@ export default defineComponent({
         .trim()
       if (!text) return `${this.job.title} at ${this.job.company} — apply via IndyHackers.`
       return text.length > 160 ? `${text.slice(0, 157).trimEnd()}…` : text
+    },
+    // ISO date (YYYY-MM-DD) the posting went live — required by Google for
+    // JobPosting. Falls back to the created date if not yet approved.
+    datePostedIso() {
+      const raw = this.job.approved_at || this.job.created
+      if (!raw) return undefined
+      const date = new Date(raw)
+      return isNaN(date.getTime()) ? undefined : date.toISOString().slice(0, 10)
+    },
+    // schema.org MonetaryAmount for the salary range, or null when unknown.
+    // Stored values are in thousands of USD/year.
+    baseSalarySchema() {
+      const { salary_min: min, salary_max: max } = this.job
+      if (!min && !max) return null
+      const value = { '@type': 'QuantitativeValue', unitText: 'YEAR' }
+      if (min) value.minValue = min * 1000
+      if (max) value.maxValue = max * 1000
+      if (min && !max) value.value = min * 1000
+      if (max && !min) value.value = max * 1000
+      return { '@type': 'MonetaryAmount', currency: 'USD', value }
+    },
+    // JobPosting structured data for this listing. schema.org allows HTML in
+    // `description`, and Google recommends the full (sanitized) description.
+    jobPostingSchema() {
+      const job = this.job
+      if (!job?.title) return null
+      const schema = {
+        '@context': 'https://schema.org',
+        '@type': 'JobPosting',
+        title: job.title,
+        description: this.sanitizedDescription || job.title,
+        hiringOrganization: {
+          '@type': 'Organization',
+          name: job.company || SITE_NAME
+        },
+        // The board serves the Indianapolis area; used as the default location
+        // since listings don't carry a per-job location field.
+        jobLocation: {
+          '@type': 'Place',
+          address: {
+            '@type': 'PostalAddress',
+            addressLocality: 'Indianapolis',
+            addressRegion: 'IN',
+            addressCountry: 'US'
+          }
+        }
+      }
+      if (this.datePostedIso) schema.datePosted = this.datePostedIso
+      if (this.baseSalarySchema) schema.baseSalary = this.baseSalarySchema
+      return schema
     },
     sanitizedHowToApply() {
       return DOMPurify.sanitize(this.job.how_to_apply)

--- a/src/main.js
+++ b/src/main.js
@@ -1,55 +1,82 @@
-import { createApp } from 'vue'
+import { ViteSSG } from 'vite-ssg'
 import { createPinia } from 'pinia'
-import { createHead } from '@unhead/vue/client'
 import { VueHeadMixin } from '@unhead/vue'
 import { createBootstrap } from 'bootstrap-vue-next'
-//import { BVToastPlugin } from 'bootstrap-vue'
-//import { jQuery } from 'jQuery'
 import PocketBase from 'pocketbase'
 import mitt from 'mitt'
 
 import 'bootstrap/dist/css/bootstrap.css'
 import 'bootstrap-vue-next/dist/bootstrap-vue-next.css'
-import '@popperjs/core/dist/umd/popper.min.js'
-import 'bootstrap/dist/js/bootstrap.min.js'
 
 import App from './App.vue'
-import router from './router'
+import { routes, scrollBehavior } from './router'
+import { SITE_URL } from './seo'
 
-async function prepareApp() {
-  if (!import.meta.env.DEV) {
-    return
-  }
+// Routes worth prerendering to static HTML: public, content-bearing pages whose
+// value is indexability. Excludes auth/admin, the query-driven single-job view,
+// the markdown export utilities, and redirects — those stay client-only.
+const PRERENDER_ROUTES = new Set([
+  '/',
+  '/about',
+  '/jobs',
+  '/sponsors',
+  '/newsletter',
+  '/calendar',
+  '/recommend-event',
+  '/code-of-conduct',
+  '/privacy',
+  '/terms',
+  '/support'
+])
 
-  const { worker } = await import('./mocks/browser')
-  return worker.start()
+// vite-ssg reads this named export from the entry to decide which paths to
+// prerender (the ViteSSG options arg does NOT carry it).
+export function includedRoutes(paths) {
+  return paths.filter((path) => PRERENDER_ROUTES.has(path))
 }
 
-const pbURL = import.meta.env.DEV ? '/' : window.location.origin
-const pocketbase = new PocketBase(pbURL)
-const emitter = mitt()
-//const toaster = useToast()
+// ViteSSG builds the app for both the client and the prerender pass. The setup
+// callback runs in both environments, so anything touching the DOM/`window` is
+// guarded behind `isClient`.
+export const createApp = ViteSSG(
+  App,
+  { routes, scrollBehavior },
+  async ({ app, router, isClient }) => {
+    // No PocketBase calls happen during prerender (components fetch in
+    // mounted/onMounted, which don't run server-side), but the client needs the
+    // real origin and `window` is undefined during the build.
+    const pbURL = import.meta.env.DEV
+      ? '/'
+      : isClient && typeof window !== 'undefined'
+        ? window.location.origin
+        : SITE_URL
+    const pocketbase = new PocketBase(pbURL)
+    const emitter = mitt()
 
-const app = createApp(App)
-const head = createHead()
-app.config.globalProperties.pocketbase = pocketbase
-app.config.globalProperties.emitter = emitter
-app.provide('pocketbase', pocketbase)
-app.provide('router', router)
-app.provide('emitter', emitter)
-//app.config.globalProperties.$bvToast = toaster
+    app.config.globalProperties.pocketbase = pocketbase
+    app.config.globalProperties.emitter = emitter
+    app.provide('pocketbase', pocketbase)
+    app.provide('router', router)
+    app.provide('emitter', emitter)
 
-//window.jQuery = jQuery
+    // Enables the Options-API `head()` option (vite-ssg installs the unhead
+    // head instance but not this mixin).
+    app.mixin(VueHeadMixin)
+    app.use(createPinia())
+    app.use(createBootstrap())
 
-app.use(head)
-// Enables the Options-API `head()` component option (reactive) alongside the
-// `useHead()` composable — used by App.vue for route-driven meta.
-app.mixin(VueHeadMixin)
-app.use(createPinia())
-app.use(createBootstrap())
-//app.use(BVToastPlugin)
-app.use(router)
+    if (isClient) {
+      // Popper and Bootstrap's JS bundle both touch `document` at import time,
+      // so they can only load in the browser.
+      import('@popperjs/core/dist/umd/popper.min.js')
+      import('bootstrap/dist/js/bootstrap.min.js')
 
-prepareApp().then(() => {
-  app.mount('#app')
-})
+      // Dev-only: start the MSW mock backend and wait for it before mounting
+      // (vite-ssg awaits this callback), so initial fetches are intercepted.
+      if (import.meta.env.DEV) {
+        const { worker } = await import('./mocks/browser')
+        await worker.start()
+      }
+    }
+  }
+)

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,12 +1,12 @@
-import { createRouter, createWebHistory } from 'vue-router'
 import HomeView from '../views/HomeView.vue'
 
-const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
-  scrollBehavior() {
-    return { top: 0 }
-  },
-  routes: [
+// vite-ssg owns router creation (it picks web vs. memory history for the client
+// vs. the prerender), so this module just exports the route table and options.
+export function scrollBehavior() {
+  return { top: 0 }
+}
+
+export const routes = [
     {
       path: '/',
       name: 'Home',
@@ -143,6 +143,3 @@ const router = createRouter({
       }
     }
   ]
-})
-
-export default router

--- a/src/seo.js
+++ b/src/seo.js
@@ -26,3 +26,34 @@ export function canonicalUrl(path) {
   const clean = (path || '/').split('?')[0].split('#')[0]
   return SITE_URL + clean
 }
+
+// Wrap a schema.org object (or array of them) as an unhead
+// <script type="application/ld+json"> descriptor. `key` lets unhead dedupe and
+// update the tag across re-renders. `<` is escaped so the JSON can never break
+// out of the surrounding <script> element (JSON-LD best practice).
+export function jsonLd(schema, key) {
+  return {
+    type: 'application/ld+json',
+    key,
+    innerHTML: JSON.stringify(schema).replace(/</g, '\\u003c')
+  }
+}
+
+// Strip HTML to plain text and cap its length — for JSON-LD / meta text fields.
+export function stripHtml(html, max = 300) {
+  const text = String(html || '')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  return max && text.length > max ? `${text.slice(0, max - 1).trimEnd()}…` : text
+}
+
+// Site-wide Organization markup, rendered on every page via App.vue.
+export const ORGANIZATION_SCHEMA = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: SITE_NAME,
+  url: SITE_URL,
+  logo: `${SITE_URL}/favicon.png`,
+  description: DEFAULT_DESCRIPTION
+}


### PR DESCRIPTION
## Part 3 of 4 — SEO improvements

Stacked on #69. **Base this on `pr2-seo-jsonld`; retarget down the stack as the earlier PRs merge.**

The big one: the site was a client-rendered SPA shipping an empty `<div id="app">`, so non-JS crawlers (Bing, DuckDuckGo, Slack/LinkedIn/Discord unfurlers, LLM crawlers) and Google's first pass saw **no** content, titles, or meta. This adopts [`vite-ssg`](https://github.com/antfu/vite-ssg) to prerender public routes to real static HTML at build time, so the unhead tags + JSON-LD from #68/#69 are baked into the served HTML.

### Changes
- **`main.js`** — `export const createApp = ViteSSG(...)`. Browser-only imports (Popper, Bootstrap's JS bundle, MSW) are gated behind `isClient`; the PocketBase base URL is `window`-safe for the Node build; MSW is awaited before mount in dev so mocks still intercept the first fetch.
- **`main.js`** — `export function includedRoutes()`: an allowlist of **11** public, content-bearing routes to prerender. Excludes auth/admin, the query-driven `/job` view, the `*-markdown` export utilities, and redirects — those stay client-only.
- **`router/index.js`** — now exports the `routes` table + `scrollBehavior` (vite-ssg owns router creation and picks web vs. memory history for client vs. prerender).
- **`package.json`** — `build` → `vite-ssg build`; kept `build:spa` as the old `vite build` path.
- **`.gitignore`** — `.vite-ssg-temp`.

### Note on unhead v2
vite-ssg 28 bundles unhead **v2** and there's no release yet that supports v3, so the whole stack is pinned to `@unhead/vue@^2` (done in #68). Two incompatible unhead copies would otherwise break SSR head capture.

### Verification
- `npm run build` prerenders 11 pages; spot-checked that each carries the right per-page `<title>`, description, canonical, OG tags, and Organization JSON-LD **in the static HTML**.
- **Hydration**: loaded `/`, `/about`, `/jobs` in Chromium against the built output — **zero** hydration/mismatch warnings, nav interactive. (Only console noise is a Google Calendar API 403 from the hardcoded dev key — pre-existing, gracefully handled.)
- Unit suite unchanged (same 3 pre-existing failures on `dev`).

### Deploy note
The Dockerfile already copies `dist` → PocketBase's `pb_public`, so no serving change is needed — `npm run build` now just emits populated HTML. Dynamic data (jobs/events/newsletter) still hydrates client-side as before.

### Follow-up
4. sitemap.xml + robots.txt + `noindex` on admin/utility routes + flesh out placeholder pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)