### PR TITLE
Silence Bootstrap SCSS deprecation warnings on startup

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -39,5 +39,17 @@ export default defineConfig({
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
     }
+  },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        // Bootstrap 5.3's SCSS still trips Dart Sass's `mixed-decls` (and
+        // related) deprecations. Those come from node_modules, not our styles,
+        // so silence dependency-originated warnings while keeping them for our
+        // own SCSS. (Dart Sass 1.77 predates `silenceDeprecations`, so use
+        // `quietDeps`.)
+        quietDeps: true
+      }
+    }
   }
 })


### PR DESCRIPTION
## Problem

Every `npm run dev` (and every build) floods the console with Dart Sass
`mixed-decls` deprecation warnings:

```
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming version.
    ┌──> node_modules/bootstrap/scss/_reboot.scss
...
Warning: 22 repetitive deprecation warnings omitted.
```

All of them originate **inside Bootstrap 5.3's SCSS** (`_reboot.scss`,
`_type.scss`, `_rfs.scss`) — not our own styles — pulled in via the
`@import 'bootstrap/scss/...'` lines in `src/assets/base.scss`. There's nothing
to fix in our code; it's Bootstrap-vs-newer-Dart-Sass.

## Fix

Enable Sass's `quietDeps` in `vite.config.js`, which suppresses deprecation
warnings that come from **dependencies** while still surfacing any in our own
SCSS:

```js
css: {
  preprocessorOptions: {
    scss: { quietDeps: true }
  }
}
```

`quietDeps` (rather than `silenceDeprecations`) because the pinned Sass is
1.77.8, which predates `silenceDeprecations` (added in Dart Sass 1.79).

## Verification

- `npm run dev` — boots clean, no deprecation output.
- `npm run build` — succeeds, no Sass warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)