### PR TITLE
Switch the /slack join captcha to reCAPTCHA v3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,8 +20,11 @@ SLACK_WEBHOOK_URL=
 # set it in production to prevent invite spam.
 # SLACK_API_TOKEN=xoxp-...
 # SLACK_SUBDOMAIN=indyhackers
+# reCAPTCHA v3 (invisible, score-based) — NOT v2. Create a v3 key at
+# https://www.google.com/recaptcha/admin/create
 # RECAPTCHA_SITE_KEY=
 # RECAPTCHA_SECRET=
+# RECAPTCHA_MIN_SCORE=0.5        # below this, requests go to the review queue
 # Where pending-request notifications go (falls back to JOB_NOTIFY_EMAIL, then sender):
 # SLACK_REVIEW_EMAIL=board@indyhackers.org
 # SLACK_AUTOAPPROVE=on          # "off" sends every request to the review queue

--- a/pb/hooks/slack.pb.js
+++ b/pb/hooks/slack.pb.js
@@ -16,8 +16,11 @@
 // Env:
 //   SLACK_API_TOKEN     Slack token with admin scope (required to send invites)
 //   SLACK_SUBDOMAIN     the *.slack.com subdomain, e.g. "indyhackers"
-//   RECAPTCHA_SITE_KEY  Google reCAPTCHA v2 site key (public)
-//   RECAPTCHA_SECRET    Google reCAPTCHA v2 secret (server-side verification)
+//   RECAPTCHA_SITE_KEY  Google reCAPTCHA v3 site key (public)
+//   RECAPTCHA_SECRET    Google reCAPTCHA v3 secret (server-side verification)
+//   RECAPTCHA_MIN_SCORE v3 score below which a request is treated as suspicious
+//                       and sent to the review queue instead of auto-approved
+//                       (default 0.5; range 0.0–1.0)
 //   SLACK_REVIEW_EMAIL  where to email the board about pending requests
 //                       (falls back to JOB_NOTIFY_EMAIL, then the sender)
 //   SLACK_WEBHOOK_URL   optional Slack webhook for pending-request pings
@@ -117,12 +120,16 @@ routerAdd("POST", "/api/slack/invite", (e) => {
         // no existing record; continue
     }
 
-    // reCAPTCHA (only enforced when a secret is configured).
+    // reCAPTCHA v3 (only enforced when a secret is configured). Unlike v2,
+    // v3 returns a risk `score` instead of a pass/fail checkbox: an invalid or
+    // expired token (or the wrong action) is a hard reject, but a valid token
+    // with a low score doesn't fail outright — it just loses the auto-approve
+    // fast path and falls to the human review queue below.
     const secret = $os.getenv("RECAPTCHA_SECRET")
     let captchaOk = false
     if (secret) {
         if (!captchaResponse) {
-            throw new BadRequestError("Please complete the captcha.")
+            throw new BadRequestError("Captcha check failed. Please try again.")
         }
         const verify = $http.send({
             url: "https://www.google.com/recaptcha/api/siteverify",
@@ -134,10 +141,16 @@ routerAdd("POST", "/api/slack/invite", (e) => {
                 "&remoteip=" + encodeURIComponent(ip),
             timeout: 15,
         })
-        captchaOk = !!(verify.json && verify.json.success)
-        if (!captchaOk) {
+        const result = verify.json || {}
+        // Invalid/expired token, or a token minted for a different action → reject.
+        if (!result.success || (result.action && result.action !== "slack_invite")) {
             throw new BadRequestError("Captcha verification failed. Please try again.")
         }
+        // v3 always returns a score; v2 tokens (no score) still pass here so a
+        // key swap doesn't hard-break. Low score → not "ok" → review queue.
+        const rawMin = parseFloat($os.getenv("RECAPTCHA_MIN_SCORE"))
+        const minScore = isNaN(rawMin) ? 0.5 : rawMin
+        captchaOk = typeof result.score !== "number" || result.score >= minScore
     }
 
     // Risk signals → auto-approve decision. Auto-approve only low-risk requests;

--- a/src/components/SlackView.vue
+++ b/src/components/SlackView.vue
@@ -39,8 +39,9 @@
           aria-hidden="true"
         />
 
-        <!-- reCAPTCHA renders here when a site key is configured -->
-        <div v-show="siteKey" ref="recaptchaEl" class="slack-form__captcha"></div>
+        <!-- reCAPTCHA v3 is invisible: no widget here. When a site key is
+             configured, a token is fetched via grecaptcha.execute() on submit
+             and Google shows its badge in the corner of the page. -->
 
         <button type="submit" class="ih-btn-primary slack-form__btn" :disabled="submitting">
           {{ submitting ? 'Sending…' : 'Send me an invite' }}
@@ -60,39 +61,45 @@
 <script setup>
 import { ref, onMounted } from 'vue'
 
+const CAPTCHA_ACTION = 'slack_invite'
+
 const email = ref('')
 const website = ref('') // honeypot — must stay empty
 const siteKey = ref('')
-const recaptchaEl = ref(null)
 
 const submitting = ref(false)
 const error = ref(null)
 const result = ref(null)
 
-let widgetId = null
-
-const renderCaptcha = () => {
-  if (!siteKey.value || widgetId !== null) return
-  if (!window.grecaptcha || !window.grecaptcha.render || !recaptchaEl.value) return
-  widgetId = window.grecaptcha.render(recaptchaEl.value, { sitekey: siteKey.value })
-}
-
+// reCAPTCHA v3: load the script with the site key so grecaptcha.execute() is
+// available. There's no visible widget — a token is minted per submission.
 const loadCaptcha = () => {
   if (!siteKey.value) return
-  if (window.grecaptcha && window.grecaptcha.render) {
-    renderCaptcha()
-    return
-  }
-  // Implicit-render callback fired by the reCAPTCHA script once it loads.
-  window.__onIhRecaptchaLoad = renderCaptcha
+  if (window.grecaptcha && window.grecaptcha.execute) return
   if (document.querySelector('script[data-ih-recaptcha]')) return
   const s = document.createElement('script')
-  s.src = 'https://www.google.com/recaptcha/api.js?onload=__onIhRecaptchaLoad&render=explicit'
+  s.src = `https://www.google.com/recaptcha/api.js?render=${encodeURIComponent(siteKey.value)}`
   s.async = true
   s.defer = true
   s.dataset.ihRecaptcha = 'true'
   document.head.appendChild(s)
 }
+
+// Resolve a fresh v3 token for this submission (empty string if captcha isn't
+// configured or the script failed to load — the server decides what to enforce).
+const getCaptchaToken = () =>
+  new Promise((resolve) => {
+    if (!siteKey.value || !window.grecaptcha || !window.grecaptcha.execute) {
+      resolve('')
+      return
+    }
+    window.grecaptcha.ready(() => {
+      window.grecaptcha
+        .execute(siteKey.value, { action: CAPTCHA_ACTION })
+        .then(resolve)
+        .catch(() => resolve(''))
+    })
+  })
 
 const fetchConfig = async () => {
   try {
@@ -108,18 +115,14 @@ const fetchConfig = async () => {
 
 const requestInvite = async () => {
   error.value = null
-
-  let captchaToken = ''
-  if (siteKey.value) {
-    captchaToken = window.grecaptcha ? window.grecaptcha.getResponse(widgetId) : ''
-    if (!captchaToken) {
-      error.value = 'Please complete the captcha.'
-      return
-    }
-  }
-
   submitting.value = true
   try {
+    const captchaToken = await getCaptchaToken()
+    if (siteKey.value && !captchaToken) {
+      error.value = 'Captcha check failed. Please try again.'
+      return
+    }
+
     const res = await fetch('/api/slack/invite', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -135,11 +138,9 @@ const requestInvite = async () => {
       result.value = data
     } else {
       error.value = data.message || 'Something went wrong. Please try again.'
-      if (siteKey.value && window.grecaptcha) window.grecaptcha.reset(widgetId)
     }
   } catch {
     error.value = 'Could not connect. Check your connection and try again.'
-    if (siteKey.value && window.grecaptcha) window.grecaptcha.reset(widgetId)
   } finally {
     submitting.value = false
   }


### PR DESCRIPTION
## Problem

The `/slack` join form threw **"ERROR for site owner: Invalid key type"**. The
form was built for reCAPTCHA **v2** (the "I'm not a robot" checkbox:
`grecaptcha.render` / `getResponse` / `reset`, server checks only
`success`), so a **v3** site key can't render in it — v2 and v3 keys aren't
interchangeable.

This moves the whole flow to **v3** (invisible, score-based).

## Changes

**Frontend — `src/components/SlackView.vue`**
- Remove the rendered checkbox `<div>` and all v2 widget logic.
- Load `api.js?render=<siteKey>` and mint a token per submit via
  `grecaptcha.execute(siteKey, { action: 'slack_invite' })`.
- v3 is invisible; Google shows its badge in the page corner (satisfies the
  attribution requirement, no extra legal text needed).

**Backend — `pb/hooks/slack.pb.js`**
- Verify the token via `siteverify`, then:
  - **hard reject** an invalid/expired token, or one whose `action` isn't
    `slack_invite`;
  - treat the v3 **score** as a risk signal — a valid-but-low-score request no
    longer 400s, it just loses the auto-approve fast path and drops into the
    existing human **review queue**.
- New `RECAPTCHA_MIN_SCORE` env (default `0.5`).
- v2 tokens (which carry no `score`) still pass, so swapping keys can't
  hard-break the endpoint.

**Docs — `.env.example`**
- Point `RECAPTCHA_SITE_KEY` / `RECAPTCHA_SECRET` at a **v3** key and document
  `RECAPTCHA_MIN_SCORE`.

## To deploy

Create a **reCAPTCHA v3** key at https://www.google.com/recaptcha/admin/create
(add your prod domain), then set `RECAPTCHA_SITE_KEY` / `RECAPTCHA_SECRET` (and
optionally `RECAPTCHA_MIN_SCORE`) on the `pocketbase` container.

## Verification

- `npm run build` — succeeds.
- `eslint` — clean; `node --check pb/hooks/slack.pb.js` — parses.
- Dev is unaffected: the MSW mock returns an empty `siteKey`, so captcha stays
  off locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)