### PR TITLE
Fix /slack invite hook: helpers unreachable in PocketBase's isolated runtimes

### DIFF
--- a/pb/hooks/slack.pb.js
+++ b/pb/hooks/slack.pb.js
@@ -27,19 +27,10 @@
 //   SLACK_AUTOAPPROVE   "off" disables auto-approval (everything queues)
 //   SLACK_RATE_PER_HOUR max invite requests per IP per hour (default 5)
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-
-// A small starter list of throwaway/temp-mail domains. Extend as needed.
-const DISPOSABLE_DOMAINS = [
-    "mailinator.com", "guerrillamail.com", "10minutemail.com", "tempmail.com",
-    "temp-mail.org", "throwawaymail.com", "yopmail.com", "getnada.com",
-    "trashmail.com", "sharklasers.com", "guerrillamailblock.com", "maildrop.cc",
-    "dispostable.com", "fakeinbox.com", "mailnesia.com", "mohmal.com",
-    "spam4.me", "tempr.email", "discard.email", "mailcatch.com",
-]
-
-const emailDomain = (email) => String(email).toLowerCase().split("@")[1] || ""
-const isDisposable = (email) => DISPOSABLE_DOMAINS.includes(emailDomain(email))
+// Constants and helpers (EMAIL_RE, isDisposable, sendSlackInvite, notifyBoard)
+// live in slack_util.js and are require()'d INSIDE each handler below —
+// PocketBase runs handlers in isolated runtimes that can't see this file's
+// module scope, so top-level declarations aren't visible at request time.
 
 // ---------------------------------------------------------------------------
 // Routes
@@ -53,6 +44,7 @@ routerAdd("GET", "/api/slack/config", (e) => {
 })
 
 routerAdd("POST", "/api/slack/invite", (e) => {
+    const util = require(`${__hooks}/slack_util.js`)
     const info = e.requestInfo()
     const body = info.body || {}
     const email = String(body.email || "").trim().toLowerCase()
@@ -65,10 +57,10 @@ routerAdd("POST", "/api/slack/invite", (e) => {
         return e.json(200, { ok: true, pending: true, msg: "Thanks! Your request is in." })
     }
 
-    if (!EMAIL_RE.test(email)) {
+    if (!util.EMAIL_RE.test(email)) {
         throw new BadRequestError("Please enter a valid email address.")
     }
-    if (isDisposable(email)) {
+    if (util.isDisposable(email)) {
         throw new BadRequestError("Please use a non-disposable email address.")
     }
 
@@ -188,141 +180,28 @@ routerAdd("POST", "/api/slack/invite", (e) => {
 
 // ---------------------------------------------------------------------------
 // Invite delivery — single path, fired whenever a row becomes "approved".
+// The sendSlackInvite / notifyBoard helpers live in slack_util.js and are
+// require()'d inside each handler (see the scope note at the top of this file).
 // ---------------------------------------------------------------------------
 
-// Sends the Slack invite for an approved record and stamps invited_at (or
-// records the error). Guarded by invited_at so it never double-sends.
-function sendSlackInvite(record) {
-    if (record.getString("status") !== "approved" || record.getString("invited_at")) {
-        return
-    }
-
-    const token = $os.getenv("SLACK_API_TOKEN")
-    const org = $os.getenv("SLACK_SUBDOMAIN")
-    if (!token || !org) {
-        console.error("[slack] SLACK_API_TOKEN / SLACK_SUBDOMAIN not configured")
-        record.set("error", "Slack not configured (missing token/subdomain)")
-        $app.save(record)
-        return
-    }
-
-    const email = record.getString("email")
-    const res = $http.send({
-        url: "https://" + org + ".slack.com/api/users.admin.invite",
-        method: "POST",
-        headers: {
-            "Content-Type": "application/x-www-form-urlencoded",
-            Authorization: "Bearer " + token,
-        },
-        body: "email=" + encodeURIComponent(email) + "&resend=true",
-        timeout: 15,
-    })
-
-    let outcome = "unknown"
-    if (res.statusCode !== 200) {
-        outcome = "http_" + res.statusCode
-        console.error("[slack] invite HTTP " + res.statusCode + ": " + res.raw)
-    } else {
-        const data = res.json || {}
-        if (data.ok || data.error === "already_invited" || data.error === "already_in_team") {
-            outcome = data.ok ? "sent" : data.error
-        } else {
-            outcome = data.error || "unknown_error"
-            console.error("[slack] invite error for " + email + ": " + outcome)
-        }
-    }
-
-    if (outcome === "sent" || outcome === "already_invited" || outcome === "already_in_team") {
-        record.set("invited_at", new Date().toISOString())
-        record.set("error", "")
-    } else {
-        record.set("error", outcome)
-    }
-    $app.save(record)
-}
-
-// Notifies the board about a pending request (email + optional Slack webhook),
-// reusing the same best-effort pattern as new-job notifications.
-function notifyBoard(record) {
-    const email = record.getString("email")
-    const country = record.getString("country") || "unknown"
-
-    try {
-        const settings = $app.settings()
-        const recipient =
-            $os.getenv("SLACK_REVIEW_EMAIL") ||
-            $os.getenv("JOB_NOTIFY_EMAIL") ||
-            settings.meta.senderAddress
-        if (recipient) {
-            const esc = (v) =>
-                String(v == null ? "" : v)
-                    .replace(/&/g, "&amp;")
-                    .replace(/</g, "&lt;")
-                    .replace(/>/g, "&gt;")
-                    .replace(/"/g, "&quot;")
-                    .replace(/'/g, "&#39;")
-            const message = new MailerMessage({
-                from: { address: settings.meta.senderAddress, name: settings.meta.senderName },
-                to: [{ address: recipient }],
-                subject: "Slack invite request pending: " + email,
-                html:
-                    "<h2>A new Slack invite request needs review</h2>" +
-                    "<ul>" +
-                    "<li>Email: " + esc(email) + "</li>" +
-                    "<li>Country: " + esc(country) + "</li>" +
-                    "<li>IP: " + esc(record.getString("ip")) + "</li>" +
-                    "</ul>" +
-                    "<p>Approve or reject it on the Slack invites admin screen.</p>",
-            })
-            $app.newMailClient().send(message)
-            console.log("[slack] pending-request email sent to " + recipient)
-        }
-    } catch (err) {
-        console.error("[slack] pending-request email failed: " + err)
-    }
-
-    try {
-        const webhook = $os.getenv("SLACK_WEBHOOK_URL")
-        if (webhook) {
-            const slackEsc = (v) =>
-                String(v == null ? "" : v).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
-            const text =
-                ":envelope_with_arrow: *New Slack invite request pending review*\n" +
-                "Email: " + slackEsc(email) + "\n" +
-                "Country: " + slackEsc(country) + "\n" +
-                "Approve or reject it on the admin screen."
-            const res = $http.send({
-                url: webhook,
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ text }),
-                timeout: 15,
-            })
-            if (res.statusCode < 200 || res.statusCode >= 300) {
-                console.error("[slack] webhook returned " + res.statusCode + ": " + res.raw)
-            }
-        }
-    } catch (err) {
-        console.error("[slack] pending-request webhook failed: " + err)
-    }
-}
-
 onRecordAfterCreateSuccess((e) => {
+    const util = require(`${__hooks}/slack_util.js`)
     const status = e.record.getString("status")
     if (status === "approved") {
-        sendSlackInvite(e.record)
+        util.sendSlackInvite(e.record)
     } else if (status === "pending") {
-        notifyBoard(e.record)
+        util.notifyBoard(e.record)
     }
     e.next()
 }, "slack_invites")
 
 onRecordAfterUpdateSuccess((e) => {
+    const util = require(`${__hooks}/slack_util.js`)
     const was = e.record.original().getString("status")
     const now = e.record.getString("status")
     // Send the invite the moment a board member flips a row to approved.
     if (was !== "approved" && now === "approved") {
-        sendSlackInvite(e.record)
+        util.sendSlackInvite(e.record)
     }
     e.next()
 }, "slack_invites")

--- a/pb/hooks/slack_util.js
+++ b/pb/hooks/slack_util.js
@@ -1,0 +1,149 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+// Shared constants + helpers for slack.pb.js.
+//
+// PocketBase runs each hook handler (routerAdd / onRecord* callbacks) in an
+// isolated JSVM runtime that CANNOT see the hook file's module scope. Anything
+// a handler needs must therefore be pulled in via require() from inside the
+// handler body (same pattern as calendar_sync.js). Keeping these here — instead
+// of at the top of slack.pb.js — is what makes them reachable at runtime.
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+// A small starter list of throwaway/temp-mail domains. Extend as needed.
+const DISPOSABLE_DOMAINS = [
+    "mailinator.com", "guerrillamail.com", "10minutemail.com", "tempmail.com",
+    "temp-mail.org", "throwawaymail.com", "yopmail.com", "getnada.com",
+    "trashmail.com", "sharklasers.com", "guerrillamailblock.com", "maildrop.cc",
+    "dispostable.com", "fakeinbox.com", "mailnesia.com", "mohmal.com",
+    "spam4.me", "tempr.email", "discard.email", "mailcatch.com",
+]
+
+const emailDomain = (email) => String(email).toLowerCase().split("@")[1] || ""
+const isDisposable = (email) => DISPOSABLE_DOMAINS.includes(emailDomain(email))
+
+// Sends the Slack invite for an approved record and stamps invited_at (or
+// records the error). Guarded by invited_at so it never double-sends.
+function sendSlackInvite(record) {
+    if (record.getString("status") !== "approved" || record.getString("invited_at")) {
+        return
+    }
+
+    const token = $os.getenv("SLACK_API_TOKEN")
+    const org = $os.getenv("SLACK_SUBDOMAIN")
+    if (!token || !org) {
+        console.error("[slack] SLACK_API_TOKEN / SLACK_SUBDOMAIN not configured")
+        record.set("error", "Slack not configured (missing token/subdomain)")
+        $app.save(record)
+        return
+    }
+
+    const email = record.getString("email")
+    const res = $http.send({
+        url: "https://" + org + ".slack.com/api/users.admin.invite",
+        method: "POST",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Authorization: "Bearer " + token,
+        },
+        body: "email=" + encodeURIComponent(email) + "&resend=true",
+        timeout: 15,
+    })
+
+    let outcome = "unknown"
+    if (res.statusCode !== 200) {
+        outcome = "http_" + res.statusCode
+        console.error("[slack] invite HTTP " + res.statusCode + ": " + res.raw)
+    } else {
+        const data = res.json || {}
+        if (data.ok || data.error === "already_invited" || data.error === "already_in_team") {
+            outcome = data.ok ? "sent" : data.error
+        } else {
+            outcome = data.error || "unknown_error"
+            console.error("[slack] invite error for " + email + ": " + outcome)
+        }
+    }
+
+    if (outcome === "sent" || outcome === "already_invited" || outcome === "already_in_team") {
+        record.set("invited_at", new Date().toISOString())
+        record.set("error", "")
+    } else {
+        record.set("error", outcome)
+    }
+    $app.save(record)
+}
+
+// Notifies the board about a pending request (email + optional Slack webhook),
+// reusing the same best-effort pattern as new-job notifications.
+function notifyBoard(record) {
+    const email = record.getString("email")
+    const country = record.getString("country") || "unknown"
+
+    try {
+        const settings = $app.settings()
+        const recipient =
+            $os.getenv("SLACK_REVIEW_EMAIL") ||
+            $os.getenv("JOB_NOTIFY_EMAIL") ||
+            settings.meta.senderAddress
+        if (recipient) {
+            const esc = (v) =>
+                String(v == null ? "" : v)
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;")
+                    .replace(/"/g, "&quot;")
+                    .replace(/'/g, "&#39;")
+            const message = new MailerMessage({
+                from: { address: settings.meta.senderAddress, name: settings.meta.senderName },
+                to: [{ address: recipient }],
+                subject: "Slack invite request pending: " + email,
+                html:
+                    "<h2>A new Slack invite request needs review</h2>" +
+                    "<ul>" +
+                    "<li>Email: " + esc(email) + "</li>" +
+                    "<li>Country: " + esc(country) + "</li>" +
+                    "<li>IP: " + esc(record.getString("ip")) + "</li>" +
+                    "</ul>" +
+                    "<p>Approve or reject it on the Slack invites admin screen.</p>",
+            })
+            $app.newMailClient().send(message)
+            console.log("[slack] pending-request email sent to " + recipient)
+        }
+    } catch (err) {
+        console.error("[slack] pending-request email failed: " + err)
+    }
+
+    try {
+        const webhook = $os.getenv("SLACK_WEBHOOK_URL")
+        if (webhook) {
+            const slackEsc = (v) =>
+                String(v == null ? "" : v).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+            const text =
+                ":envelope_with_arrow: *New Slack invite request pending review*\n" +
+                "Email: " + slackEsc(email) + "\n" +
+                "Country: " + slackEsc(country) + "\n" +
+                "Approve or reject it on the admin screen."
+            const res = $http.send({
+                url: webhook,
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ text }),
+                timeout: 15,
+            })
+            if (res.statusCode < 200 || res.statusCode >= 300) {
+                console.error("[slack] webhook returned " + res.statusCode + ": " + res.raw)
+            }
+        }
+    } catch (err) {
+        console.error("[slack] pending-request webhook failed: " + err)
+    }
+}
+
+module.exports = {
+    EMAIL_RE,
+    DISPOSABLE_DOMAINS,
+    emailDomain,
+    isDisposable,
+    sendSlackInvite,
+    notifyBoard,
+}


### PR DESCRIPTION
## Symptom

Submitting the `/slack` join form fails. The frontend shows *"Something went
wrong while processing your request."* (PocketBase's generic error) and the
PocketBase log shows:

```
ReferenceError: EMAIL_RE is not defined at /pb.js:14:10(51)
```

## Root cause

PocketBase executes each hook handler (`routerAdd` / `onRecord*` callbacks) in
an **isolated JSVM runtime that cannot see the hook file's module scope**. In
`slack.pb.js`, `EMAIL_RE`, `DISPOSABLE_DOMAINS`, `isDisposable()`,
`sendSlackInvite()` and `notifyBoard()` were declared at the top of the file and
then used *inside* the handlers — so at request time they're all `undefined`.
`EMAIL_RE` is simply the first one the invite handler reaches (right after the
honeypot check), so that's where it throws.

Pre-existing since the Slack feature landed; it surfaced now because the old v2
"Invalid key type" captcha error used to block submission before the request
ever reached the server.

## Fix

Move the shared constants/helpers into `pb/hooks/slack_util.js` and
`require()` them **inside** each handler — exactly the pattern
`calendar_sync.pb.js` already uses (`require(\`${__hooks}/calendar_sync.js\`)`).
Plain `.js` files aren't auto-loaded as hooks, so there's no double-execution.

No behavior change — the invite/approval path is byte-for-byte the same logic;
it just actually runs now.

## Verification

- `node --check` passes on both files.
- No remaining bare references to the moved symbols in `slack.pb.js` (all go
  through `util.*`); `require()` present in all three handlers that need it.
- Dev is unaffected (MSW mocks these endpoints).

**After merge/deploy:** re-test on dev.indyhackers.org — with a valid US IP +
good v3 score the request should return "Invite sent", and the row should land
in `slack_invites`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)