### PR TITLE
Seed the admin role + fix the roles lookup in /api/admin/promote

### DIFF
--- a/pb/hooks/admin.pb.js
+++ b/pb/hooks/admin.pb.js
@@ -10,11 +10,13 @@ routerAdd('POST', '/api/admin/promote', async (e) => {
       throw new Error('Invalid user token')
     }
 
-    // Check if the user has an "admin" role
-    $app.expandRecord(userAuth, ['role'], null)
-    const userRole = userAuth.expandedOne('role')
-    console.log(JSON.stringify(userRole))
-    if (!userRole || userRole.get('name') !== 'admin') {
+    // Check if the user has the "admin" role. `roles` is a multi-relation, so
+    // expand all of them and look for one named "admin" (matches the frontend
+    // guard and the slack_invites API rule).
+    $app.expandRecord(userAuth, ['roles'], null)
+    const userRoles = userAuth.expandedAll('roles') || []
+    const isAdmin = userRoles.some((r) => r.get('name') === 'admin')
+    if (!isAdmin) {
       throw new Error('User does not have the admin role')
     }
 

--- a/pb/migrations/025_seed_admin_role.js
+++ b/pb/migrations/025_seed_admin_role.js
@@ -1,0 +1,31 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+// Seed the "admin" role that gates the admin screens (job & Slack-invite
+// approval) and the slack_invites API rules (`@request.auth.roles.name ?=
+// 'admin'`). Without this row there's no way to grant a user admin access short
+// of creating the role by hand. Re-runnable: upserts by name.
+migrate(
+  (app) => {
+    const collection = app.findCollectionByNameOrId('roles')
+
+    let record
+    try {
+      record = app.findFirstRecordByData('roles', 'name', 'admin')
+    } catch (_) {
+      record = new Record(collection)
+    }
+    record.set('name', 'admin')
+    record.set('description', 'Full administrative access: job & Slack-invite approval and the admin screens.')
+    record.set('level', 100)
+    app.save(record)
+  },
+  (app) => {
+    // Down: remove the seeded admin role.
+    try {
+      const record = app.findFirstRecordByData('roles', 'name', 'admin')
+      app.delete(record)
+    } catch (_) {
+      // already gone
+    }
+  }
+)


### PR DESCRIPTION
Two related gaps around the app-level **`admin` role** — the thing that gates
the admin screens (job & Slack-invite approval) and the `slack_invites` API
rules (`@request.auth.roles.name ?= 'admin'`).

## 1. Seed the `admin` role — `pb/migrations/025_seed_admin_role.js`

Migration `002` creates the `roles` collection and the `users.roles` relation,
but nothing ever created an actual `admin` role record. On a fresh DB there was
no role to assign, so granting someone admin meant hand-creating the role first.

New migration upserts an `admin` role (`level: 100`), idempotent by name (same
re-runnable pattern as `024_seed_topics.js`), with a matching `down` that
removes it.

## 2. Fix `/api/admin/promote` — `pb/hooks/admin.pb.js`

The endpoint expanded `'role'` (singular) and called `expandedOne('role')`, but
the users field is **`roles`** — a multi-relation. So the expand found nothing
and every call threw *"User does not have the admin role"*.

Now it expands `roles` and checks whether **any** related role is named
`admin`, consistent with the frontend router guard and the `slack_invites`
collection rule.

## Granting access after this lands

1. Deploy → migration seeds the `admin` role automatically.
2. In the PocketBase admin UI: Collections → `users` → open the user → add the
   `admin` role to their `roles` field → save.
3. They log out/in and can use `/admin/slack-invites`.

## Verification

- `node --check` passes on both files.
- No remaining singular `'role'` references in `admin.pb.js`.
- Dev is unaffected (MSW mocks these endpoints; migrations run only against a
  real PocketBase).

## Note (out of scope)

`002`'s `down` migration filters on `field.name !== 'role'` (should be
`'roles'`), so a rollback of `002` would orphan the relation field. Minor and
only matters on a `002` rollback — left alone to avoid editing an
already-applied migration, but happy to fix in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)