### PR TITLE
Fix /admin bouncing legit admins: open the roles collection view rule

### DIFF
--- a/pb/migrations/026_open_roles_view_rule.js
+++ b/pb/migrations/026_open_roles_view_rule.js
@@ -1,0 +1,24 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+// The roles collection (migration 002) was created with only listRule set, so
+// viewRule defaulted to null (superusers only). That silently breaks the
+// frontend admin guard: it reads a user's role names via
+// `getOne('users', id, { expand: 'roles' })`, but PocketBase only expands a
+// relation when the related collection's viewRule passes for the request. With
+// viewRule null, a normal signed-in user's roles never expand, so even a
+// legitimately-assigned admin is bounced to /not-authorized.
+//
+// Open viewRule to match the already-public listRule. Role records aren't
+// sensitive (name/description/level), and the list is already public.
+migrate(
+  (app) => {
+    const roles = app.findCollectionByNameOrId('roles')
+    roles.viewRule = ''
+    app.save(roles)
+  },
+  (app) => {
+    const roles = app.findCollectionByNameOrId('roles')
+    roles.viewRule = null
+    app.save(roles)
+  }
+)


### PR DESCRIPTION
## Symptom

A user with the `admin` role assigned still gets sent to `/not-authorized` when
visiting `/admin` on dev.indyhackers.org.

## Root cause

The frontend admin guard (`src/main.js`) reads a user's role names on the
client:

```js
pocketbase.collection('users').getOne(id, { expand: 'roles' })
```

PocketBase only expands a relation when the **related collection's viewRule**
passes for the request. The `roles` collection (migration `002`) was created
with **only `listRule: ''`** set, so `viewRule` defaulted to `null` (superusers
only). For a normal signed-in user the `roles` expand is silently dropped → the
guard sees no role names → `/not-authorized`, even for a correctly-assigned
admin.

Server-side rules that reference roles (e.g. `slack_invites`'
`@request.auth.roles.name ?= 'admin'`) were unaffected — those evaluate
internally with full access, not through the client-facing viewRule. That's why
the role "works" server-side but the client guard fails.

## Fix

`pb/migrations/026_open_roles_view_rule.js` sets `roles.viewRule = ''` to match
the already-public `listRule`. Role records aren't sensitive (name/description/
level) and are already listable by anyone. `down` restores `null`.

## Verify after deploy

- `/admin` loads for a user who has the `admin` role.
- DevTools → the `users/records/<id>?expand=roles` response now includes a
  populated `expand.roles`.
- PocketBase admin UI → Collections → `roles` → API rules → **View** is no
  longer superusers-only.

If a user is *still* bounced after this, check that their assigned role's
`name` is exactly `admin` (the guard is case-sensitive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)