### PR TITLE
Link pending-invite notifications to the review screen

### DIFF
--- a/pb/hooks/slack_util.js
+++ b/pb/hooks/slack_util.js
@@ -79,6 +79,12 @@ function notifyBoard(record) {
     const email = record.getString("email")
     const country = record.getString("country") || "unknown"
 
+    // Absolute link to the review screen (same SITE_URL/appURL fallback the job
+    // notification emails use). Empty if neither is configured — callers then
+    // fall back to plain "the admin screen" text rather than a broken link.
+    const base = ($os.getenv("SITE_URL") || $app.settings().meta.appURL || "").replace(/\/+$/, "")
+    const adminUrl = base ? base + "/admin/slack-invites" : ""
+
     try {
         const settings = $app.settings()
         const recipient =
@@ -104,7 +110,9 @@ function notifyBoard(record) {
                     "<li>Country: " + esc(country) + "</li>" +
                     "<li>IP: " + esc(record.getString("ip")) + "</li>" +
                     "</ul>" +
-                    "<p>Approve or reject it on the Slack invites admin screen.</p>",
+                    (adminUrl
+                        ? '<p>Approve or reject it on the <a href="' + esc(adminUrl) + '">Slack invites admin screen</a>.</p>'
+                        : "<p>Approve or reject it on the Slack invites admin screen.</p>"),
             })
             $app.newMailClient().send(message)
             console.log("[slack] pending-request email sent to " + recipient)
@@ -118,11 +126,14 @@ function notifyBoard(record) {
         if (webhook) {
             const slackEsc = (v) =>
                 String(v == null ? "" : v).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+            const cta = adminUrl
+                ? "Approve or reject it: <" + adminUrl + "|Slack invites admin>"
+                : "Approve or reject it on the Slack invites admin screen."
             const text =
                 ":envelope_with_arrow: *New Slack invite request pending review*\n" +
                 "Email: " + slackEsc(email) + "\n" +
                 "Country: " + slackEsc(country) + "\n" +
-                "Approve or reject it on the admin screen."
+                cta
             const res = $http.send({
                 url: webhook,
                 method: "POST",


### PR DESCRIPTION
## What

The pending-request notifications (`notifyBoard` in `pb/hooks/slack_util.js`)
now link straight to `/admin/slack-invites` so a reviewer can jump to the queue:

- **Slack webhook** (the ask): the CTA becomes a Slack link —
  `Approve or reject it: <https://…/admin/slack-invites|Slack invites admin>`.
- **Board email** (for consistency): "Slack invites admin screen" is now an
  `<a href>` to the same URL.

## URL building

Built from `SITE_URL`, falling back to PocketBase's app URL
(`settings.meta.appURL`) — the same pattern the job-notification emails already
use (`jobs.pb.js`). If **neither** is configured, both messages degrade to the
previous plain-text wording rather than emitting a broken/relative link.

> Heads up: for the links to render, set `SITE_URL` (e.g.
> `https://dev.indyhackers.org`) on the `pocketbase` container, or make sure
> PocketBase's Application URL is set in settings.

## Verification

- `node --check` passes.
- Slack `<url|text>` mrkdwn syntax; email uses a standard anchor (URL escaped).
- Dev unaffected (these fire only against a real backend with `SLACK_WEBHOOK_URL`
  / SMTP configured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)