### PR TITLE
Slack: support contact on queued message + open CoC link in new tab

### DIFF
--- a/pb/hooks/slack.pb.js
+++ b/pb/hooks/slack.pb.js
@@ -135,7 +135,7 @@ routerAdd("POST", "/api/slack/invite", (e) => {
                 return e.json(200, {
                     ok: true,
                     pending: true,
-                    msg: "Your request is already in the queue — hang tight for approval.",
+                    msg: "Your request is already in the queue — hang tight for approval. You can email admin@indyhackers.org if you need assistance.",
                 })
             }
             // rejected → fall through and let them try again

--- a/src/components/SlackView.vue
+++ b/src/components/SlackView.vue
@@ -125,7 +125,7 @@
           <input v-model="cocAgreed" type="checkbox" required :disabled="submitting" />
           <span>
             I agree to the
-            <RouterLink to="/code-of-conduct">code of conduct</RouterLink>.
+            <RouterLink to="/code-of-conduct" target="_blank" rel="noopener noreferrer">code of conduct</RouterLink>.
           </span>
         </label>
 


### PR DESCRIPTION
Re-does two small changes that were accidentally pushed to branches **after**
their PRs (#84, #86) had already been squash-merged, so they never reached `dev`.

- **`pb/hooks/slack.pb.js`** — the "already in the queue" response for a
  duplicate pending request now adds a support contact:
  > Your request is already in the queue — hang tight for approval. You can
  > email admin@indyhackers.org if you need assistance.
- **`src/components/SlackView.vue`** — the join form's code-of-conduct link
  opens in a new tab (`target="_blank"` + `rel="noopener noreferrer"`) so
  reading the CoC doesn't blow away a half-filled form.

## Verification
- `node --check` on the hook; ESLint clean on the component.

🤖 Generated with [Claude Code](https://claude.com/claude-code)