### PR TITLE
Fix empty geolocation: read Cloudflare headers with PocketBase's key normalization

### DIFF
--- a/pb/hooks/slack.pb.js
+++ b/pb/hooks/slack.pb.js
@@ -85,20 +85,28 @@ routerAdd("POST", "/api/slack/invite", (e) => {
 
     const ip = e.realIP()
     const headers = info.headers || {}
-    const country = String(headers["cf-ipcountry"] || "").toUpperCase()
-    const userAgent = String(headers["user_agent"] || headers["user-agent"] || "")
+    // PocketBase normalizes request header keys to lowercase with hyphens turned
+    // into underscores (e.g. "CF-IPCity" -> "cf_ipcity"). Read both forms so the
+    // Cloudflare headers match regardless — the previous hyphenated lookups never
+    // hit, which is why country and geolocation came back empty.
+    const header = (name) => {
+        const key = name.toLowerCase()
+        return String(headers[key.replace(/-/g, "_")] || headers[key] || "")
+    }
+    const country = header("cf-ipcountry").toUpperCase()
+    const userAgent = header("user-agent")
 
     // Approximate IP geolocation from Cloudflare. These headers are only present
     // when the "Add visitor location headers" managed transform is enabled in
     // the Cloudflare dashboard (cf-ipcountry is always sent; the rest are not).
     // All empty locally / off Cloudflare — the admin card just hides what's blank.
     const geo = {
-        city: String(headers["cf-ipcity"] || ""),
-        region: String(headers["cf-region"] || ""),
-        continent: String(headers["cf-ipcontinent"] || ""),
-        postal: String(headers["cf-postal-code"] || ""),
-        lat: String(headers["cf-iplatitude"] || ""),
-        lon: String(headers["cf-iplongitude"] || ""),
+        city: header("cf-ipcity"),
+        region: header("cf-region"),
+        continent: header("cf-ipcontinent"),
+        postal: header("cf-postal-code"),
+        lat: header("cf-iplatitude"),
+        lon: header("cf-iplongitude"),
     }
 
     // Rate limit per IP.


### PR DESCRIPTION
## Symptom

"Add visitor location headers" is enabled in Cloudflare, but the invite approval
screen still shows no geolocation.

## Root cause

PocketBase's `e.requestInfo().headers` normalizes every header key to
**lowercase with hyphens replaced by underscores** — `CF-IPCity` → `cf_ipcity`,
`User-Agent` → `user_agent`.

The hook read the Cloudflare headers with **hyphenated** keys
(`headers["cf-ipcity"]`, `headers["cf-ipcountry"]`, …), which never match the
normalized keys — so `geo` was always empty. The tell was right there: the
`userAgent` line already used the underscore form (`headers["user_agent"]`)
because that's the one that actually works.

This also means **`country` has silently been empty all along**, so
auto-approve (which requires `country === "US"`) never fired — every request
went to the review queue.

## Fix

A small `header()` helper that looks up the underscore-normalized key (with a
hyphen fallback, so it's correct either way), used for `country`, `user-agent`,
and all the `cf-*` geo headers.

## After merge/deploy — how to confirm

1. Make sure dev.indyhackers.org's DNS record is **proxied** (orange cloud) in
   Cloudflare — the headers are only added on proxied traffic.
2. Submit a **new** invite request (existing rows won't backfill).
3. The new row's card should show **Approx. location (IP)** + **Coordinates**,
   and **Country** should now be populated (US requests may even auto-approve).

## Verification

- `node --check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)