### PR TITLE
Fix long IPv6 addresses overflowing the Slack invite review card

### DIFF
--- a/src/components/admin/SlackInvites.vue
+++ b/src/components/admin/SlackInvites.vue
@@ -276,6 +276,13 @@ onMounted(load)
   margin: 1.25rem 0 0;
 }
 
+/* Grid cells default to min-width:auto, so a long unbreakable value (e.g. an
+   IPv6 address) forces the cell wider and overlaps its neighbours. Let cells
+   shrink and let their values wrap. */
+.slack-admin__meta > div {
+  min-width: 0;
+}
+
 .slack-admin__meta dt,
 .slack-admin__connection dt {
   font-family: var(--font-mono);
@@ -290,6 +297,7 @@ onMounted(load)
   margin: 0;
   font-size: 0.9375rem;
   color: var(--text-primary);
+  overflow-wrap: anywhere;
 }
 
 .slack-admin__maplink {


### PR DESCRIPTION
## Symptom

On `/admin/slack-invites`, a request from an **IPv6** address overflows its
column and writes over the "Code of conduct: agreed" cell.

## Cause

The card's meta grid uses `grid-template-columns: repeat(auto-fit, minmax(9rem,
1fr))`. An IPv6 address (e.g. `2001:0db8:85a3:0000:0000:8a2e:0370:7334`) is a
long string with no spaces, so it won't wrap — and CSS grid/flex cells default
to `min-width: auto`, which stops the cell from shrinking below its content.
Result: the value bleeds into the neighbouring cell.

## Fix (CSS only, `SlackInvites.vue`)

- `.slack-admin__meta > div { min-width: 0 }` — let the grid cells shrink.
- `.slack-admin__meta dd { overflow-wrap: anywhere }` — let long values (IPv6,
  long coordinates) wrap within the cell.

IPv4 rows are unaffected (short enough not to wrap).

## Verification

- `npm run build` passes; ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)