### PR TITLE
Fix notification showing reCAPTCHA 'fail' when the score passed

### DIFF
--- a/pb/hooks/slack_util.js
+++ b/pb/hooks/slack_util.js
@@ -111,9 +111,13 @@ function notifyBoard(record) {
     const cocAgreed = record.getBool("coc_agreed")
 
     // Stored risk signals used for the auto-approval decision (geo lives here too).
+    // A JSON field comes back from record.get() as raw JSON in the JSVM, not a
+    // live JS object, so signals.* would read as undefined (the notification
+    // showed reCAPTCHA "fail" and blank geo/US-visitor even though the stored
+    // record was correct). Parse the string form so the values are usable.
     let signals = {}
     try {
-        signals = record.get("signals") || {}
+        signals = JSON.parse(record.getString("signals") || "{}")
     } catch (_) {
         signals = {}
     }


### PR DESCRIPTION
## Symptom

A test invite showed **reCAPTCHA: fail** in the Slack/email notification, while
the approval screen showed **0.9 (min 0.5) — pass** for the same request.

## Cause

The approval screen reads the record over the **REST API** (properly-parsed
JSON), so it sees `captcha_score: 0.9`, `captcha_ok: true` → pass.

The notification is built in the `notifyBoard` PocketBase hook, which read the
signals via `record.get("signals")`. In the JSVM a JSON field comes back as
**raw JSON, not a live JS object**, so every `signals.*` access was `undefined`
— `captchaSignalLabel` fell through to `captcha_ok ? "pass" : "fail"` with an
undefined `captcha_ok` → **"fail"**. The same bug blanked the US-visitor and geo
lines in the notification.

## Fix

Parse the JSON string form (`JSON.parse(record.getString("signals") || "{}")`)
so the notification uses the same values the record actually stores.

## Verification

- `node --check` passes.
- After deploy: a passing request should show **reCAPTCHA: 0.9 (min 0.5) — pass**
  (and correct US-visitor / geo) in the notification, matching the admin screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)