### PR TITLE
security: seed initial superuser from env, not a committed password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@
 VITE_GOOGLE_CALENDAR_API_KEY=your_api_key_here
 
 # --- PocketBase server-side (set on the `pocketbase` container, not Vite) ---
+# Initial superuser seed (migration 001), used only on a FRESH database. Leave
+# INITIAL_ADMIN_PASSWORD unset to skip seeding and create the first superuser
+# out-of-band: `pocketbase superuser create <email> <password>`.
+INITIAL_ADMIN_EMAIL=admin@indyhackers.org
+INITIAL_ADMIN_PASSWORD=
 # Base URL used to build links in outgoing emails (e.g. the self-service job
 # management link). Falls back to PocketBase Settings > Application URL if unset.
 SITE_URL=https://indyhackers.com

--- a/pb/migrations/001_add_admin.js
+++ b/pb/migrations/001_add_admin.js
@@ -1,18 +1,40 @@
 // pb_migrations/1687801090_initial_admin.js
 migrate(
   (app) => {
+    // Seed the initial superuser from the environment instead of a committed
+    // password. Set these before first boot on a fresh database:
+    //   INITIAL_ADMIN_EMAIL     (optional; defaults to admin@indyhackers.org)
+    //   INITIAL_ADMIN_PASSWORD  (required to seed; min 8 chars per PocketBase)
+    //
+    // If INITIAL_ADMIN_PASSWORD is unset we skip creation entirely — create the
+    // first superuser out-of-band instead:
+    //   pocketbase superuser create <email> <password>
+    //
+    // NOTE: editing this already-applied migration only affects *fresh*
+    // databases. It does NOT rotate an existing production superuser — rotate
+    // that by hand (the previously committed password must be considered
+    // compromised).
+    const email = $os.getenv('INITIAL_ADMIN_EMAIL') || 'admin@indyhackers.org'
+    const password = $os.getenv('INITIAL_ADMIN_PASSWORD')
+    if (!password) {
+      console.warn(
+        '[migrations] INITIAL_ADMIN_PASSWORD not set; skipping initial superuser seed. ' +
+          'Create one with: pocketbase superuser create <email> <password>'
+      )
+      return
+    }
+
     const superusers = app.findCollectionByNameOrId('_superusers')
     const admin = new Record(superusers)
-
-    // Set the admin details
-    admin.set('email', 'admin@indyhackers.org')
-    admin.set('password', 'go west, young hackie, hack the planet !')
+    admin.set('email', email)
+    admin.set('password', password)
 
     app.save(admin)
   },
   (app) => {
     try {
-      const admin = app.findAuthRecordByEmail('_superusers', 'admin@indyhackers.org')
+      const email = $os.getenv('INITIAL_ADMIN_EMAIL') || 'admin@indyhackers.org'
+      const admin = app.findAuthRecordByEmail('_superusers', email)
       app.delete(admin)
     } catch {
       // Silent errors (probably already deleted)


### PR DESCRIPTION
## Summary
Fixes finding **C1 (Critical)** from the `dev` security review.

`pb/migrations/001_add_admin.js` hardcoded a PocketBase **superuser** email and plaintext password directly in the repo:

```js
admin.set('email', 'admin@indyhackers.org')
admin.set('password', 'go west, young hackie, hack the planet !')
```

This migration runs automatically on PocketBase startup. On any fresh database it seeds a full superuser with credentials that are **public in git history** — anyone can browse to `/_/` and log in, giving complete database/settings/user takeover.

## Change
- Seed the initial superuser from `INITIAL_ADMIN_EMAIL` / `INITIAL_ADMIN_PASSWORD`.
- If `INITIAL_ADMIN_PASSWORD` is unset, **skip** seeding (with a warning) — create the first superuser out-of-band via `pocketbase superuser create <email> <password>`.
- Document the new vars in `.env.example`.

## ⚠️ Operational follow-up (not fixable in code)
- Editing this already-applied migration only affects **fresh** databases; it does not re-run on production.
- **Rotate the `admin@indyhackers.org` superuser password on production now** and treat the old passphrase as compromised.
- Consider scrubbing the secret from git history (`git filter-repo`) if this repo is or ever was public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)