### PR TITLE
security: block non-superusers from changing users.roles

### DIFF
--- a/pb/hooks/roles_guard.pb.js
+++ b/pb/hooks/roles_guard.pb.js
@@ -1,0 +1,66 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+// Privilege-escalation guard for the `users.roles` relation.
+//
+// PocketBase has no per-field write rules, and the users collection lets a
+// signed-in user update their own record. The `roles` collection is publicly
+// listable, so the "admin" role id is trivially discoverable. Without this hook
+// a normal user could PATCH their own user record to add themselves to the
+// admin role and then call POST /api/admin/promote (see admin.pb.js), which
+// mints a full PocketBase superuser token — a complete account takeover.
+//
+// Policy: the `roles` relation may only be set/changed by a request
+// authenticated as a PocketBase superuser. That's how the admin screens assign
+// roles today (the console acts with a superuser token). Regular users — even
+// ones already in the admin role, acting with their own user token — cannot
+// alter roles on any user record, including their own.
+//
+// These are *request* hooks: they fire only for API-driven writes, never for
+// internal $app.save(...) calls, so server-side role management still works.
+
+// A multi-relation reads back as an array of ids; normalize to a sorted list so
+// order/shape differences don't register as a change.
+function sortedRoleIds(record) {
+    const roles = record ? record.get('roles') : null
+    const ids = Array.isArray(roles) ? roles.slice() : roles ? [roles] : []
+    return ids.map(String).sort()
+}
+
+function rolesChanged(before, after) {
+    if (before.length !== after.length) return true
+    for (let i = 0; i < before.length; i++) {
+        if (before[i] !== after[i]) return true
+    }
+    return false
+}
+
+// Prefer the built-in helper; fall back to inspecting the auth record's
+// collection so the guard still holds if the helper is unavailable.
+function isSuperuserRequest(e) {
+    try {
+        if (typeof e.hasSuperuserAuth === 'function') return e.hasSuperuserAuth()
+    } catch (_) {
+        /* fall through */
+    }
+    try {
+        return !!e.auth && e.auth.collection().name === '_superusers'
+    } catch (_) {
+        return false
+    }
+}
+
+onRecordCreateRequest((e) => {
+    if (sortedRoleIds(e.record).length > 0 && !isSuperuserRequest(e)) {
+        throw new ForbiddenError('Setting roles is not allowed.')
+    }
+    e.next()
+}, 'users')
+
+onRecordUpdateRequest((e) => {
+    const before = sortedRoleIds(e.record.original())
+    const after = sortedRoleIds(e.record)
+    if (rolesChanged(before, after) && !isSuperuserRequest(e)) {
+        throw new ForbiddenError('Changing roles is not allowed.')
+    }
+    e.next()
+}, 'users')


### PR DESCRIPTION
## Summary
Fixes finding **C2 (Critical)** from the `dev` security review — a privilege-escalation path to a full PocketBase superuser.

### The chain
1. Signup is open (default `users.createRule` + Google OAuth), so anyone can get an authenticated user.
2. The `roles` collection is publicly listable (`listRule: ''`, view opened in migration 026), so the **admin** role id is trivially discoverable.
3. `roles` is a normal relation field on `users`, and no migration overrides the default self-update `users.updateRule` (`id = @request.auth.id`). PocketBase has **no per-field write rules**, so a user can `PATCH` their own record to set `roles: [adminId]`.
4. `POST /api/admin/promote` (`admin.pb.js`) then mints a **superuser auth token** for any user in the admin role → complete database/settings takeover.

### The fix
Add request-scoped hooks (`pb/hooks/roles_guard.pb.js`) on the `users` collection that reject any create/update which **sets or changes the `roles` relation** unless the request is authenticated as a **superuser**. That matches how roles are legitimately assigned today (the admin console acts with a superuser token).

- Request hooks fire only for API-driven writes, **not** internal `$app.save(...)`, so server-side/role-management flows are unaffected.
- Unchanged-`roles` profile updates (client re-sending the same array) are allowed — only actual changes by non-superusers are blocked.

### Note
This closes the escalation regardless of the exact live `users.updateRule`. Independently, please still verify that rule in the admin UI and consider whether app-admins should receive a real superuser token at all (see the review's C2 remediation notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)