### PR TITLE
security: don't stash the superuser token in localStorage

### DIFF
--- a/src/components/AdminLogin.vue
+++ b/src/components/AdminLogin.vue
@@ -47,17 +47,12 @@ export default {
           throw new Error(errorData.error || 'Unknown error')
         }
 
-        const data = await response.json()
-
-        localStorage.setItem(
-          '__pb_superuser_auth__',
-          JSON.stringify({
-            token: data.token,
-            record: data.record
-          })
-        )
-
-        // Redirect to PocketBase admin console
+        // The promote endpoint ensures this user has a _superusers record so
+        // they can reach the console. We intentionally do NOT persist the
+        // returned superuser token in web storage: a superuser JWT sitting in
+        // localStorage is readable by any XSS on the page and would escalate
+        // straight to full backend compromise. (Nothing read this key anyway —
+        // PocketBase's admin console manages its own auth.) Hand off to /_/.
         window.location.href = '/_/'
       } catch (error) {
         errorMessage.value = error.message || 'Failed to promote user to admin'


### PR DESCRIPTION
## Summary
Fixes finding **H1 (High)** from the `dev` security review.

`AdminLogin.vue` wrote the full PocketBase **superuser JWT** returned by `/api/admin/promote` into `localStorage`:

```js
localStorage.setItem('__pb_superuser_auth__', JSON.stringify({ token: data.token, record: data.record }))
```

A superuser token in web storage is readable by **any XSS** on the site (including via a compromised npm dependency), turning a single script injection into complete backend compromise. It also amplifies the C2 escalation.

## Change
Remove the `localStorage` write; keep the redirect to `/_/`.

The `__pb_superuser_auth__` key is **written but never read** anywhere in the app — PocketBase's admin console manages its own auth — so this is a pure security win with **no behavior change**.

## Follow-up (out of scope here)
- `/api/admin/promote` still returns the superuser token in its JSON body (now unused by the client); consider dropping it from the response.
- Longer term, the app-admin → superuser bridge itself is worth revisiting (the review's H1/C2 notes) so admins don't need a superuser token in the browser at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)