### PR TITLE
security: gate job reads on approval, block self-approval, sanitize job HTML

### DIFF
--- a/pb/hooks/__tests__/jobs_util.spec.js
+++ b/pb/hooks/__tests__/jobs_util.spec.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+// jobs_util.js is a CommonJS PocketBase hook module (the JSVM uses require /
+// module.exports), while this repo is ESM and Vitest runs files through Vite's
+// ESM transform (and import.meta.url isn't a file: URL under jsdom). Load the
+// raw source from the repo root and evaluate it as CommonJS so we exercise the
+// exact file the hooks run. Its only global reference ($app) lives inside
+// requestIsPrivileged, which we don't call here.
+const src = readFileSync(resolve(process.cwd(), 'pb/hooks/jobs_util.js'), 'utf8')
+const mod = { exports: {} }
+new Function('module', 'exports', 'require', src)(mod, mod.exports, () => ({}))
+const { sanitizeRichText } = mod.exports
+
+describe('sanitizeRichText (jobs rich-text defense-in-depth)', () => {
+  it('keeps the formatting tags TipTap emits', () => {
+    const out = sanitizeRichText('<p>Hi <strong>bold</strong> <em>it</em></p><ul><li>a</li></ul>')
+    expect(out).toBe('<p>Hi <strong>bold</strong> <em>it</em></p><ul><li>a</li></ul>')
+  })
+
+  it('removes <script>/<style>/<iframe>/<svg> and their contents', () => {
+    expect(sanitizeRichText('<script>alert(1)</script>keep')).toBe('keep')
+    expect(sanitizeRichText('<style>body{}</style>keep')).toBe('keep')
+    expect(sanitizeRichText('<iframe src="evil"></iframe>keep')).toBe('keep')
+    expect(sanitizeRichText('<svg><script>alert(1)</script></svg>keep')).toBe('keep')
+  })
+
+  it('strips event-handler and other attributes but keeps the tag', () => {
+    expect(sanitizeRichText('<p onclick="steal()">hi</p>')).toBe('<p>hi</p>')
+  })
+
+  it('drops disallowed tags but keeps their text', () => {
+    expect(sanitizeRichText('<div><span>plain</span></div>')).toBe('plain')
+    expect(sanitizeRichText('<img src=x onerror=alert(1)>')).toBe('')
+  })
+
+  it('neutralizes javascript:/data: hrefs (incl. entity/whitespace obfuscation)', () => {
+    for (const href of [
+      'javascript:alert(1)',
+      'java&#115;cript:alert(1)',
+      'jav\tascript:alert(1)',
+      'data:text/html,<script>alert(1)</script>'
+    ]) {
+      const out = sanitizeRichText(`<a href="${href}">x</a>`)
+      expect(out).toBe('<a>x</a>')
+      expect(out.toLowerCase()).not.toContain('alert(1)')
+    }
+  })
+
+  it('preserves safe http/mailto/relative hrefs and adds rel', () => {
+    expect(sanitizeRichText('<a href="https://ok.com/jobs">a</a>')).toBe(
+      '<a href="https://ok.com/jobs" rel="nofollow ugc noopener noreferrer">a</a>'
+    )
+    expect(sanitizeRichText('<a href="mailto:a@b.com">m</a>')).toContain('href="mailto:a@b.com"')
+    expect(sanitizeRichText('<a href="/careers">r</a>')).toContain('href="/careers"')
+  })
+
+  it('strips HTML comments', () => {
+    expect(sanitizeRichText('<!-- <script>x</script> -->keep')).toBe('keep')
+  })
+
+  it('normalizes tag casing', () => {
+    expect(sanitizeRichText('<STRONG>up</STRONG>')).toBe('<strong>up</strong>')
+  })
+})

--- a/pb/hooks/jobs.pb.js
+++ b/pb/hooks/jobs.pb.js
@@ -7,17 +7,41 @@ onRecordEnrich((e) => {
     e.next()
 }, "jobs")
 
-// Generate the unguessable manage token server-side before the record is
-// persisted, so the (account-less) submitter can later edit / take down their
-// own post without anyone being able to forge the link.
-onRecordCreate((e) => {
-    if (!e.record.getString("edit_token")) {
-        e.record.set("edit_token", $security.randomString(40))
+// The jobs create rule is public (account-less submission). Make sure an
+// anonymous request can't self-publish by POSTing approved=true — force the
+// moderation state unless the requester is an admin/superuser. Approval happens
+// later on the /admin/jobs screen, which flips `approved`. This is a request
+// hook, so it sees the caller's auth and never fires for internal $app.save.
+onRecordCreateRequest((e) => {
+    const jobs = require(`${__hooks}/jobs_util.js`)
+    if (!jobs.requestIsPrivileged(e)) {
+        e.record.set("approved", false)
+        e.record.set("approved_at", "")
+        e.record.set("filled", false)
     }
     e.next()
 }, "jobs")
 
+// Generate the unguessable manage token server-side before the record is
+// persisted, so the (account-less) submitter can later edit / take down their
+// own post without anyone being able to forge the link. Also sanitize the
+// rich-text fields on the way in (defense in depth beneath the render-time
+// DOMPurify — see jobs_util.js).
+onRecordCreate((e) => {
+    const jobs = require(`${__hooks}/jobs_util.js`)
+    if (!e.record.getString("edit_token")) {
+        e.record.set("edit_token", $security.randomString(40))
+    }
+    jobs.sanitizeJobHtml(e.record)
+    e.next()
+}, "jobs")
+
 onRecordUpdate((e) => {
+    const jobs = require(`${__hooks}/jobs_util.js`)
+    // Re-sanitize on every write — this also covers the /api/jobs/manage PATCH
+    // route, which edits the body and persists via $app.save (firing this hook).
+    jobs.sanitizeJobHtml(e.record)
+
     const wasApproved = e.record.original().getBool("approved")
     const isApproved = e.record.getBool("approved")
 

--- a/pb/hooks/jobs_util.js
+++ b/pb/hooks/jobs_util.js
@@ -1,0 +1,116 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+// Shared helpers for jobs.pb.js. PocketBase runs each hook handler in an
+// isolated JSVM runtime that can't see the hook file's module scope, so these
+// are require()'d from inside each handler (same pattern as slack_util.js).
+
+// ---------------------------------------------------------------------------
+// Rich-text sanitizer for the `editor` (HTML) job fields.
+//
+// DEFENSE IN DEPTH ONLY. The authoritative XSS control is the render-time
+// DOMPurify pass in the Vue components (JobListing.vue et al.) — do NOT drop
+// that on account of this. But the jobs collection is publicly creatable
+// (account-less submission) and the /api/jobs/manage route lets the holder of
+// an edit token change the body, so untrusted HTML reaches the database. This
+// strips the dangerous constructs before anything is stored or served (e.g. to
+// the Atom feed or any future consumer that forgets to sanitize).
+//
+// Allowlist approach: keep only the small tag set TipTap's StarterKit emits,
+// drop every attribute except a scheme-checked href on <a>, and remove
+// <script>/<style>/<iframe>/... together with their contents. Unknown tags are
+// unwrapped (inner text kept, tag markup dropped).
+// ---------------------------------------------------------------------------
+
+const ALLOWED_TAGS = {
+    p: 1, br: 1, hr: 1, strong: 1, b: 1, em: 1, i: 1, u: 1, s: 1, strike: 1, del: 1,
+    ul: 1, ol: 1, li: 1, blockquote: 1, pre: 1, code: 1,
+    h1: 1, h2: 1, h3: 1, h4: 1, h5: 1, h6: 1, a: 1,
+}
+
+function attrEscape(v) {
+    return String(v)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+}
+
+// Returns a safe href string, or null to drop the attribute. Decodes numeric
+// entities and strips control/whitespace before testing the scheme so tricks
+// like "java&#115;cript:" or "java\tscript:" can't smuggle a dangerous scheme.
+function safeHref(raw) {
+    const url = String(raw == null ? '' : raw).trim()
+    const probe = url
+        .replace(/&#x([0-9a-f]+);?/gi, (_, h) => String.fromCharCode(parseInt(h, 16)))
+        .replace(/&#(\d+);?/g, (_, d) => String.fromCharCode(parseInt(d, 10)))
+        .replace(/[\s\u0000-\u001f]+/g, '')
+        .toLowerCase()
+    if (/^(https?:|mailto:)/.test(probe)) return url // absolute http(s)/mailto
+    if (/^[/#?]/.test(probe)) return url // root-relative / anchor / query
+    // A bare relative path ("careers/123") is fine; anything with an explicit
+    // scheme we didn't allowlist (javascript:, data:, vbscript:, …) is dropped.
+    if (/^[a-z][a-z0-9+.-]*:/i.test(probe)) return null
+    return url
+}
+
+function sanitizeRichText(html) {
+    let out = String(html == null ? '' : html)
+
+    // 1) Remove dangerous elements together with their contents.
+    out = out.replace(
+        /<(script|style|iframe|object|embed|svg|math|noscript|template)\b[\s\S]*?<\/\1\s*>/gi,
+        ''
+    )
+
+    // 2) Strip HTML comments / declarations (could hide markup on re-parse).
+    out = out.replace(/<!--[\s\S]*?-->/g, '').replace(/<![\s\S]*?>/g, '')
+
+    // 3) Walk every remaining tag: allowlist the name, scrub the attributes.
+    out = out.replace(/<(\/?)\s*([a-zA-Z][a-zA-Z0-9]*)\b([^>]*)>/g, (m, slash, name, attrs) => {
+        const tag = name.toLowerCase()
+        if (!ALLOWED_TAGS[tag]) return '' // unwrap: drop tag markup, keep text
+        if (slash) return '</' + tag + '>'
+        if (tag === 'a') {
+            const hm = /\bhref\s*=\s*("([^"]*)"|'([^']*)'|([^\s"'>]+))/i.exec(attrs)
+            const href = hm ? safeHref(hm[2] || hm[3] || hm[4]) : null
+            return href
+                ? '<a href="' + attrEscape(href) + '" rel="nofollow ugc noopener noreferrer">'
+                : '<a>'
+        }
+        return '<' + tag + '>' // known formatting tag, all attributes removed
+    })
+
+    return out
+}
+
+// Sanitize the editor fields on a jobs record in place.
+function sanitizeJobHtml(record) {
+    for (const field of ['description', 'how_to_apply']) {
+        const raw = record.getString(field)
+        if (raw) record.set(field, sanitizeRichText(raw))
+    }
+}
+
+// Whether the current request is from a superuser or a user in the admin role.
+// Used to decide who may create a job that skips the moderation queue.
+function requestIsPrivileged(e) {
+    try {
+        if (typeof e.hasSuperuserAuth === 'function' && e.hasSuperuserAuth()) return true
+    } catch (_) {
+        /* fall through to role check */
+    }
+    const auth = e.auth
+    if (!auth) return false
+    try {
+        $app.expandRecord(auth, ['roles'], null)
+        return (auth.expandedAll('roles') || []).some((r) => r.get('name') === 'admin')
+    } catch (_) {
+        return false
+    }
+}
+
+module.exports = {
+    sanitizeRichText,
+    sanitizeJobHtml,
+    requestIsPrivileged,
+}

--- a/pb/migrations/029_jobs_public_read_approved_only.js
+++ b/pb/migrations/029_jobs_public_read_approved_only.js
@@ -1,0 +1,29 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+// Stop the jobs collection from exposing unapproved posts over the API.
+//
+// Migration 004 set listRule/viewRule to "" (fully public), so ANY caller could
+// list or fetch jobs that a moderator hasn't approved yet — unreviewed,
+// account-less, publicly-submitted content (see the jobs create rule). The
+// frontend only ever shows approved jobs, but the raw collection API returned
+// everything.
+//
+// Gate public reads to approved jobs, with an admin-role override so the
+// /admin/jobs approvals screen can still list/preview the pending queue with a
+// board member's own token. The token-based /api/jobs/manage routes read
+// server-side via $app and are unaffected.
+migrate(
+  (app) => {
+    const jobs = app.findCollectionByNameOrId('jobs')
+    jobs.listRule = "approved = true || @request.auth.roles.name ?= 'admin'"
+    jobs.viewRule = "approved = true || @request.auth.roles.name ?= 'admin'"
+    app.save(jobs)
+  },
+  (app) => {
+    // Revert to the migration-004 state (fully public read).
+    const jobs = app.findCollectionByNameOrId('jobs')
+    jobs.listRule = ''
+    jobs.viewRule = ''
+    app.save(jobs)
+  }
+)


### PR DESCRIPTION
## Summary
Fixes finding **M1 (Medium)** from the `dev` security review. The `jobs` collection is publicly readable and publicly creatable (account-less submission — migration 017 removed the `user` relation), which opened three gaps.

### 1. Unapproved jobs were exposed over the API
`listRule`/`viewRule` were `""` (migration 004), so any caller could list/fetch jobs a moderator hadn't approved — unreviewed, publicly-submitted content. The frontend only shows approved jobs, but the raw collection API returned everything.

**Fix — migration 029:** gate public reads to `approved = true`, with an admin-role override:
```
approved = true || @request.auth.roles.name ?= 'admin'
```
Verified against every read path: `JobsList` (`approved = true && …`), `JobsMarkdown` (`approved = true`), public `/job?id=` view, `/admin/jobs` (admin token, lists `approved = false` via the override), and `/api/jobs/manage` (server-side, unaffected).

### 2. Anyone could self-publish by POSTing `approved: true`
With a public create rule and no field protection, an anonymous request could create an already-approved (live) job, skipping moderation entirely.

**Fix:** a new `onRecordCreateRequest("jobs")` hook forces `approved`/`filled`/`approved_at` to the moderation state unless the requester is an admin/superuser. Approval still happens later on `/admin/jobs`. (Request hook → sees caller auth, never fires for internal `$app.save`.)

### 3. Rich-text fields stored raw HTML
`description`/`how_to_apply` are `editor` (HTML) fields stored verbatim. Render-time DOMPurify is the authoritative XSS control, but untrusted HTML still lands in the DB and could reach a consumer that forgets to sanitize.

**Fix:** `pb/hooks/jobs_util.js` adds an **allowlist** sanitizer run on create *and* update (the update path also covers the `/api/jobs/manage` PATCH, which persists via `$app.save`). It keeps only the tags TipTap's StarterKit emits, strips every attribute except a scheme-checked `href` on `<a>`, and removes `<script>/<style>/<iframe>/<svg>/…` with their contents. **Explicitly defense-in-depth beneath DOMPurify — not a replacement.** Attribute stripping means cosmetic hints like `<ol start>` / code-block language classes don't survive; acceptable tradeoff.

## Tests
New `pb/hooks/__tests__/jobs_util.spec.js` (8 cases, all passing): script/style/iframe/svg removal, event-handler + attribute stripping, `javascript:`/`data:` href neutralization incl. `java&#115;cript:` / `jav\tascript:` obfuscation, and preservation of safe `http`/`mailto`/relative hrefs.

## Verification
- `node --check` on all changed hooks/migration; `npm run build:spa` passes.
- Unit tests: **+8 new passing**; the 4 pre-existing failures (`SignupPage`, `LoginPage`, `CalendarEvents`, `HelloWorld`) are unchanged and unrelated.

## Notes for reviewers
- Public job creation stays open by design (account-less submission → moderation queue). Rate-limiting/captcha on job creation is a separate spam-hardening follow-up, not in this PR.
- Migration 029 touches only `list`/`view`; independent of #100's migration 028 (`update`/`delete`). No conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)