### PR TITLE
Redirect legacy slack.indyhackers.org to /slack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,11 @@ SLACK_WEBHOOK_URL=
 # SLACK_REVIEW_EMAIL=board@indyhackers.org
 # SLACK_AUTOAPPROVE=on          # "off" sends every request to the review queue
 # SLACK_RATE_PER_HOUR=5         # max invite requests per IP per hour
+# Legacy slack.indyhackers.org subdomain redirect (pb/hooks/slack_redirect.pb.js).
+# Any request whose Host matches SLACK_REDIRECT_HOST is 302'd to SLACK_REDIRECT_TARGET.
+# Defaults below are used if unset; override only if the hostnames change.
+# SLACK_REDIRECT_HOST=slack.indyhackers.org
+# SLACK_REDIRECT_TARGET=https://www.indyhackers.org/slack
 
 # --- Google login (OAuth2) ---
 # Read by pb/hooks/oauth.pb.js; configures the Google provider at startup.

--- a/pb/hooks/slack_redirect.pb.js
+++ b/pb/hooks/slack_redirect.pb.js
@@ -1,0 +1,33 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+// Legacy slack.indyhackers.org -> www.indyhackers.org/slack redirect.
+//
+// The Slack-invite functionality used to live in a separate `slackin` Node app
+// behind slack.indyhackers.org. It now lives at /slack in this site (see
+// slack.pb.js + the SPA route). Once the Cloudflare tunnel for that subdomain
+// is re-pointed at this app, this global middleware catches any request whose
+// Host is the slack subdomain and redirects it to the canonical /slack page so
+// old links keep working.
+//
+// Env (both optional):
+//   SLACK_REDIRECT_HOST    Host that should be redirected
+//                          (default "slack.indyhackers.org")
+//   SLACK_REDIRECT_TARGET  Absolute URL to redirect to
+//                          (default "https://www.indyhackers.org/slack")
+
+routerUse((e) => {
+    const fromHost = ($os.getenv("SLACK_REDIRECT_HOST") || "slack.indyhackers.org").toLowerCase()
+    const target = $os.getenv("SLACK_REDIRECT_TARGET") || "https://www.indyhackers.org/slack"
+
+    // e.request.host may include a port (e.g. in local testing); strip it and
+    // compare case-insensitively.
+    const host = (e.request.host || "").toLowerCase().split(":")[0]
+
+    if (host === fromHost) {
+        // 302 (temporary) so browsers don't cache the mapping — makes it easy to
+        // change or retire this redirect later. Switch to 301 if it's permanent.
+        return e.redirect(302, target)
+    }
+
+    return e.next()
+})


### PR DESCRIPTION
## Summary

Now that the Slack-invite functionality lives at `/slack` in this app (`slack.pb.js` + the SPA route), this wires up `slack.indyhackers.org` to redirect there so the Cloudflare tunnel for that subdomain can be re-pointed at this site.

Adds a global PocketBase `routerUse` middleware (`pb/hooks/slack_redirect.pb.js`) that runs on every request and `302`-redirects any request whose `Host` is `slack.indyhackers.org` → `https://www.indyhackers.org/slack`. Host match is case-insensitive and strips any `:port`.

## Config

Both hostnames are overridable via env, defaulting to the production values so no config is required:

- `SLACK_REDIRECT_HOST` (default `slack.indyhackers.org`)
- `SLACK_REDIRECT_TARGET` (default `https://www.indyhackers.org/slack`)

Documented in `.env.example`.

## Notes

- **302 (temporary)** so browsers don't hard-cache the mapping during the tunnel cutover. Switch to `301` if the move is considered permanent.
- On the Cloudflare tunnel side, keep original `Host` header pass-through on (the default) — if the tunnel rewrites Host to `www.indyhackers.org`, the middleware won't fire.
- Redirects **every path** on that host to the canonical `/slack`, since the subdomain's only purpose now is the invite flow.

## Testing

No local PocketBase binary (it's fetched during the Docker build), so the redirect wasn't exercised at runtime; the host-matching logic was unit-tested in isolation (case, port, non-match). To smoke-test the built container:

```
curl -sI -H 'Host: slack.indyhackers.org' http://localhost:8090/
# expect: 302 with Location: https://www.indyhackers.org/slack
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)