### PR TITLE
docs(env): document calendar-sync vars in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,11 @@ SLACK_WEBHOOK_URL=
 #   https://<your-domain>/api/oauth2-redirect
 # GOOGLE_OAUTH_CLIENT_ID=
 # GOOGLE_OAUTH_CLIENT_SECRET=
+
+# --- Google Calendar sync (events) ---
+# Read by the PocketBase backend (pb/hooks/calendar_sync.js), NOT the Vite
+# frontend. An hourly cron pulls a public Google Calendar into `events`; the
+# sync throws (and the cron logs an error) if the first two are unset.
+# GOOGLE_API_KEY=              # server-side Google API key with Calendar API enabled
+# GOOGLE_CALENDAR_ID=          # the public calendar to sync (e.g. ...@group.calendar.google.com)
+# CALENDAR_SYNC_WINDOW_DAYS=90 # how far ahead to sync; defaults to 90


### PR DESCRIPTION
## Summary
Adds the three Google-Calendar-sync backend env vars to `.env.example`. They're read by `pb/hooks/calendar_sync.js` via `$os.getenv` but were previously undocumented — surfaced while auditing prerequisites for the `dev` → `main` release (#106).

| Var | Notes |
|-----|-------|
| `GOOGLE_API_KEY` | **required** — server-side Google API key with the Calendar API enabled |
| `GOOGLE_CALENDAR_ID` | **required** — the public calendar to sync |
| `CALENDAR_SYNC_WINDOW_DAYS` | optional, defaults to `90` |

The hourly `calendar-sync` cron (`pb/hooks/calendar_sync.pb.js`) throws and logs an error if the first two are unset, so an operator deploying from `.env.example` alone would get a silently failing events sync.

Note: these are distinct from the frontend's `VITE_GOOGLE_CALENDAR_API_KEY` (build-time, browser) — these are read server-side on the PocketBase container.

## Change
Docs only — one new commented block in `.env.example`. No code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)