### PR TITLE
chore(docker): use npm ci and cache the deps layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,15 @@ FROM node:24 as vue-builder
 
 WORKDIR /app/ui
 
+# Install deps first, from the lockfile, so this layer is cached across builds
+# that only touch source. npm ci is lockfile-exact and fails if package.json and
+# package-lock.json drift, unlike npm i.
+COPY package.json package-lock.json ./
+RUN npm ci
+
 COPY . .
 
-RUN npm i && npm run build
+RUN npm run build
 
 # --------
 


### PR DESCRIPTION
## Summary
The `vue-builder` stage installed dependencies with `COPY . . && RUN npm i`. Two issues:

- **`npm i`, not `npm ci`** — non-reproducible: it can silently update `package-lock.json` and tolerates drift between `package.json` and the lockfile instead of failing fast.
- **No layer caching** — `COPY . .` before install invalidates the deps layer on *any* source change, so every build reinstalls all ~600 packages from scratch.

Surfaced while auditing the `dev` → `main` release (#106), which adds new deps (`vite-ssg`, `@unhead/vue`).

## Change
```dockerfile
COPY package.json package-lock.json ./
RUN npm ci
COPY . .
RUN npm run build
```
Deps install from the lockfile in a cached layer; only `npm run build` re-runs when source changes.

## Verification
Locally on **Node 24** (matches the `node:24` builder image):
- `npm ci` → clean install, lockfile in sync (0 vulnerabilities)
- `npm run build` → vite-ssg build + 11 prerendered pages + sitemap written

No app/behavior change — build output is identical; this only affects how the image is built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)