### PR TITLE
fix(roles-guard): make the users.roles hook work under PocketBase's isolated runtimes

### DIFF
--- a/pb/hooks/roles_guard.pb.js
+++ b/pb/hooks/roles_guard.pb.js
@@ -17,49 +17,25 @@
 //
 // These are *request* hooks: they fire only for API-driven writes, never for
 // internal $app.save(...) calls, so server-side role management still works.
-
-// A multi-relation reads back as an array of ids; normalize to a sorted list so
-// order/shape differences don't register as a change.
-function sortedRoleIds(record) {
-    const roles = record ? record.get('roles') : null
-    const ids = Array.isArray(roles) ? roles.slice() : roles ? [roles] : []
-    return ids.map(String).sort()
-}
-
-function rolesChanged(before, after) {
-    if (before.length !== after.length) return true
-    for (let i = 0; i < before.length; i++) {
-        if (before[i] !== after[i]) return true
-    }
-    return false
-}
-
-// Prefer the built-in helper; fall back to inspecting the auth record's
-// collection so the guard still holds if the helper is unavailable.
-function isSuperuserRequest(e) {
-    try {
-        if (typeof e.hasSuperuserAuth === 'function') return e.hasSuperuserAuth()
-    } catch (_) {
-        /* fall through */
-    }
-    try {
-        return !!e.auth && e.auth.collection().name === '_superusers'
-    } catch (_) {
-        return false
-    }
-}
+//
+// The sortedRoleIds / rolesChanged / isSuperuserRequest helpers live in
+// roles_guard_util.js and are require()'d inside each handler below —
+// PocketBase runs handlers in isolated runtimes that can't see this file's
+// module scope, so top-level declarations aren't visible at request time.
 
 onRecordCreateRequest((e) => {
-    if (sortedRoleIds(e.record).length > 0 && !isSuperuserRequest(e)) {
+    const util = require(`${__hooks}/roles_guard_util.js`)
+    if (util.sortedRoleIds(e.record).length > 0 && !util.isSuperuserRequest(e)) {
         throw new ForbiddenError('Setting roles is not allowed.')
     }
     e.next()
 }, 'users')
 
 onRecordUpdateRequest((e) => {
-    const before = sortedRoleIds(e.record.original())
-    const after = sortedRoleIds(e.record)
-    if (rolesChanged(before, after) && !isSuperuserRequest(e)) {
+    const util = require(`${__hooks}/roles_guard_util.js`)
+    const before = util.sortedRoleIds(e.record.original())
+    const after = util.sortedRoleIds(e.record)
+    if (util.rolesChanged(before, after) && !util.isSuperuserRequest(e)) {
         throw new ForbiddenError('Changing roles is not allowed.')
     }
     e.next()

--- a/pb/hooks/roles_guard_util.js
+++ b/pb/hooks/roles_guard_util.js
@@ -1,0 +1,43 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+// Shared helpers for roles_guard.pb.js. PocketBase runs each hook handler in
+// an isolated JSVM runtime that can't see the hook file's module scope, so
+// these are require()'d from inside each handler (same pattern as
+// slack_util.js / jobs_util.js).
+
+// A multi-relation reads back as an array of ids; normalize to a sorted list so
+// order/shape differences don't register as a change.
+function sortedRoleIds(record) {
+    const roles = record ? record.get('roles') : null
+    const ids = Array.isArray(roles) ? roles.slice() : roles ? [roles] : []
+    return ids.map(String).sort()
+}
+
+function rolesChanged(before, after) {
+    if (before.length !== after.length) return true
+    for (let i = 0; i < before.length; i++) {
+        if (before[i] !== after[i]) return true
+    }
+    return false
+}
+
+// Prefer the built-in helper; fall back to inspecting the auth record's
+// collection so the guard still holds if the helper is unavailable.
+function isSuperuserRequest(e) {
+    try {
+        if (typeof e.hasSuperuserAuth === 'function') return e.hasSuperuserAuth()
+    } catch (_) {
+        /* fall through */
+    }
+    try {
+        return !!e.auth && e.auth.collection().name === '_superusers'
+    } catch (_) {
+        return false
+    }
+}
+
+module.exports = {
+    sortedRoleIds,
+    rolesChanged,
+    isSuperuserRequest,
+}


### PR DESCRIPTION
## Summary
- Production auth (signup + login) is currently broken with `ReferenceError: sortedRoleIds is not defined` — introduced by #98.
- PocketBase runs each hook handler in an isolated JSVM that can't see the hook file's top-level scope, so `sortedRoleIds()`, `rolesChanged()`, and `isSuperuserRequest()` were undefined at request time.
- Moves those helpers into `pb/hooks/roles_guard_util.js` and `require()`s them inside each handler — same pattern already used to fix the identical issue in `slack.pb.js` (8e6b54b). No change to the authorization logic itself.

## Test plan
- [x] Reproduced the crash locally against PocketBase v0.39.4 (matching the Dockerfile) using the unmodified hook file — confirmed identical error/stack trace.
- [x] Applied the fix and confirmed signup (`POST /api/collections/users/records`) and login (`POST /api/collections/users/auth-with-password`) both succeed with no error.
- [ ] Deploy and confirm login works in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)