### PR TITLE
Production release: merge dev → main

### DIFF
--- a/pb/hooks/jobs.pb.js
+++ b/pb/hooks/jobs.pb.js
@@ -237,3 +237,57 @@ onRecordAfterUpdateSuccess((e) => {
 
     e.next()
 }, "jobs")
+
+// Moderator decision → Slack webhook ping recording WHO did it. These run on the
+// API request (not the model hooks above) because only the request event carries
+// the acting admin as e.auth. In the admin UI, "approve" flips approved
+// false→true (an update) and "reject" deletes the pending row (a delete), so we
+// cover both. Each pings only after e.next() commits, and the webhook post is
+// best-effort (util.postSlackWebhook never throws). Helpers live in slack_util.js
+// (the Slack-webhook home) and are require()'d here per the isolated-runtime rule.
+
+// Approve = approved flips false→true; un-publishing (true→false) is reported too.
+onRecordUpdateRequest((e) => {
+    const util = require(`${__hooks}/slack_util.js`)
+    const r = e.record
+    const wasApproved = r.original().getBool("approved")
+    e.next()
+    const isApproved = r.getBool("approved")
+    if (wasApproved === isApproved) return
+    try {
+        const esc = util.slackEscape
+        const text = [
+            isApproved
+                ? ":white_check_mark: *Job approved & published*"
+                : ":leftwards_arrow_with_hook: *Job un-published*",
+            "*" + esc(r.getString("title")) + "* at *" + esc(r.getString("company")) + "*",
+            "*" + (isApproved ? "Approved" : "Unapproved") + " by:* " + esc(util.adminLabel(e.auth)),
+        ].join("\n")
+        util.postSlackWebhook(text)
+    } catch (err) {
+        console.error("[jobs] decision webhook failed: " + err)
+    }
+}, "jobs")
+
+// Reject = the pending row is deleted from the admin queue. Read the fields we
+// need BEFORE e.next() removes the record. A delete of an already-approved job
+// is a live-listing takedown rather than a rejection, so word it accordingly.
+onRecordDeleteRequest((e) => {
+    const util = require(`${__hooks}/slack_util.js`)
+    const r = e.record
+    const title = r.getString("title")
+    const company = r.getString("company")
+    const wasApproved = r.getBool("approved")
+    e.next()
+    try {
+        const esc = util.slackEscape
+        const text = [
+            ":x: *Job " + (wasApproved ? "removed" : "rejected") + "*",
+            "*" + esc(title) + "* at *" + esc(company) + "*",
+            "*" + (wasApproved ? "Removed" : "Rejected") + " by:* " + esc(util.adminLabel(e.auth)),
+        ].join("\n")
+        util.postSlackWebhook(text)
+    } catch (err) {
+        console.error("[jobs] delete webhook failed: " + err)
+    }
+}, "jobs")

--- a/pb/hooks/slack.pb.js
+++ b/pb/hooks/slack.pb.js
@@ -351,3 +351,24 @@ onRecordUpdate((e) => {
     }
     e.next()
 }, "slack_invites")
+
+// Board decision → Slack webhook ping recording WHO approved/rejected. This runs
+// on the API update request (not the model hook above) because only the request
+// event carries the acting admin as e.auth. We fire only after e.next() commits
+// the update: a manual approval whose Slack invite fails makes the model hook
+// throw, e.next() rejects, and no misleading "approved" ping goes out. The ping
+// itself is best-effort and wrapped so it can never turn a committed update into
+// an error response.
+onRecordUpdateRequest((e) => {
+    const util = require(`${__hooks}/slack_util.js`)
+    const was = e.record.original().getString("status")
+    e.next()
+    const now = e.record.getString("status")
+    if (was !== now && (now === "approved" || now === "rejected")) {
+        try {
+            util.notifyInviteDecision(e.record, now, e.auth)
+        } catch (err) {
+            console.error("[slack] decision webhook failed: " + err)
+        }
+    }
+}, "slack_invites")

--- a/pb/hooks/slack_util.js
+++ b/pb/hooks/slack_util.js
@@ -528,6 +528,69 @@ function notifyBoard(record, autoApproved) {
     }
 }
 
+// Slack mrkdwn reserves &, <, > — escape them in any interpolated text.
+const slackEscape = (v) =>
+    String(v == null ? "" : v).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+
+// Best-effort POST of a plain-text message to the configured Slack webhook.
+// No-ops when SLACK_WEBHOOK_URL is unset; never throws (logs on failure) so a
+// notification can't block the DB operation that triggered it.
+function postSlackWebhook(text) {
+    const webhook = $os.getenv("SLACK_WEBHOOK_URL")
+    if (!webhook) return
+    try {
+        const res = $http.send({
+            url: webhook,
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ text: text }),
+            timeout: 15,
+        })
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+            console.error("[slack] webhook returned " + res.statusCode + ": " + res.raw)
+        }
+    } catch (err) {
+        console.error("[slack] webhook post failed: " + err)
+    }
+}
+
+// Human-readable identifier for the acting admin from a request event's auth
+// record — "email (id)" so the notification says who did it and links to the
+// exact account. Falls back gracefully if auth is missing or emailless.
+function adminLabel(authRecord) {
+    if (!authRecord) return "unknown admin"
+    const id = authRecord.id
+    let email = ""
+    try {
+        email = authRecord.getString("email")
+    } catch (_) {
+        email = ""
+    }
+    return email ? email + " (" + id + ")" : id
+}
+
+// Posts a Slack ping when a board member approves or rejects an invite request,
+// naming the acting admin. `decision` is "approved" or "rejected"; `authRecord`
+// is the request's e.auth. Best-effort (delegates to postSlackWebhook).
+function notifyInviteDecision(record, decision, authRecord) {
+    const approved = decision === "approved"
+    const email = record.getString("email")
+    const name = [record.getString("first_name"), record.getString("last_name")]
+        .filter(Boolean).join(" ") || "(no name given)"
+    const base = ($os.getenv("SITE_URL") || $app.settings().meta.appURL || "").replace(/\/+$/, "")
+    const adminUrl = base ? base + "/admin/slack-invites" : ""
+
+    const lines = [
+        approved ? ":white_check_mark: *Slack invite approved*" : ":x: *Slack invite rejected*",
+        "*Name:* " + slackEscape(name),
+        "*Email:* " + slackEscape(email),
+        "*" + (approved ? "Approved" : "Rejected") + " by:* " + slackEscape(adminLabel(authRecord)),
+        adminUrl ? "<" + adminUrl + "|Open the Slack invites admin>" : "",
+    ].filter(Boolean)
+
+    postSlackWebhook(lines.join("\n"))
+}
+
 module.exports = {
     EMAIL_RE,
     DISPOSABLE_DOMAINS,
@@ -538,4 +601,8 @@ module.exports = {
     slackInviteOutcome,
     inviteErrorMessage,
     notifyBoard,
+    slackEscape,
+    postSlackWebhook,
+    adminLabel,
+    notifyInviteDecision,
 }

--- a/pb/hooks/slack_util.js
+++ b/pb/hooks/slack_util.js
@@ -577,16 +577,13 @@ function notifyInviteDecision(record, decision, authRecord) {
     const email = record.getString("email")
     const name = [record.getString("first_name"), record.getString("last_name")]
         .filter(Boolean).join(" ") || "(no name given)"
-    const base = ($os.getenv("SITE_URL") || $app.settings().meta.appURL || "").replace(/\/+$/, "")
-    const adminUrl = base ? base + "/admin/slack-invites" : ""
 
     const lines = [
         approved ? ":white_check_mark: *Slack invite approved*" : ":x: *Slack invite rejected*",
         "*Name:* " + slackEscape(name),
         "*Email:* " + slackEscape(email),
         "*" + (approved ? "Approved" : "Rejected") + " by:* " + slackEscape(adminLabel(authRecord)),
-        adminUrl ? "<" + adminUrl + "|Open the Slack invites admin>" : "",
-    ].filter(Boolean)
+    ]
 
     postSlackWebhook(lines.join("\n"))
 }


### PR DESCRIPTION
## Production release

Merges `dev` into `main` to ship the latest reviewed work to production.

### Included

- **Slack webhook notifications when admins approve/reject invites & jobs** (#114) — posts to the existing `SLACK_WEBHOOK_URL` whenever a board admin approves or rejects a Slack invite request or a job-board submission, naming the acting admin (`email (userId)`) for an audit trail. Reuses the existing webhook env var; no new configuration and no schema changes.

### Notes

- Content diff vs `main` is limited to the three PocketBase hook files (`pb/hooks/slack_util.js`, `pb/hooks/slack.pb.js`, `pb/hooks/jobs.pb.js`), +139 lines, purely additive.
- No migrations, no env/config changes required for this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)