### PR TITLE
Job board: rich-text toolbar, fuller confirmation email, admin tweaks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,13 @@
 SITE_URL=https://indyhackers.com
 # Where new-job moderator notifications are sent (falls back to the SMTP sender).
 JOB_NOTIFY_EMAIL=
-# Optional Slack incoming webhook — pings for new-job notifications and pending
-# Slack-invite requests.
+# Optional Slack incoming webhook (PRIVATE moderator channel) — pings for new-job
+# submissions, moderator decisions, and pending Slack-invite requests.
 SLACK_WEBHOOK_URL=
+# Optional Slack incoming webhook for the PUBLIC #jobs channel — an approved job
+# is announced here (title, company, link) so members see new openings. Keep this
+# separate from SLACK_WEBHOOK_URL so moderator pings don't leak to members.
+SLACK_JOBS_WEBHOOK_URL=
 
 # --- Slack join page (/slack) + invite approval queue ---
 # Read by the PocketBase backend (pb/hooks/slack.pb.js), NOT the Vite frontend.

--- a/pb/hooks/jobs.pb.js
+++ b/pb/hooks/jobs.pb.js
@@ -266,6 +266,35 @@ onRecordAfterUpdateSuccess((e) => {
         console.error("[jobs] approval email failed: " + err)
     }
 
+    // Public announcement: when a job goes live (approved false→true), post to the
+    // public #jobs Slack channel so members see the opening. Independent and
+    // best-effort — uses its own SLACK_JOBS_WEBHOOK_URL (the public channel), not
+    // the private moderator webhook. Needs an absolute base URL to build the link;
+    // if none is configured we skip rather than post a useless relative link.
+    try {
+        const wasApproved = r.original().getBool("approved")
+        const isApproved = r.getBool("approved")
+        if (!wasApproved && isApproved) {
+            const util = require(`${__hooks}/slack_util.js`)
+            const base = ($os.getenv("SITE_URL") || $app.settings().meta.appURL || "").replace(/\/+$/, "")
+            if (base) {
+                const esc = util.slackEscape
+                const jobUrl = base + "/job?id=" + r.id
+                const text = [
+                    ":briefcase: *New job on the board*",
+                    "*" + esc(r.getString("title")) + "* at *" + esc(r.getString("company")) + "*",
+                    "<" + jobUrl + "|View the posting>",
+                ].join("\n")
+                util.postJobsChannelWebhook(text)
+                console.log("[jobs] public #jobs announcement posted for " + r.id)
+            } else {
+                console.warn("[jobs] no SITE_URL/appURL; skipping public #jobs announcement (need an absolute link)")
+            }
+        }
+    } catch (err) {
+        console.error("[jobs] public #jobs announcement failed: " + err)
+    }
+
     e.next()
 }, "jobs")
 

--- a/pb/hooks/jobs.pb.js
+++ b/pb/hooks/jobs.pb.js
@@ -125,13 +125,22 @@ onRecordAfterCreateSuccess((e) => {
                     .replace(/</g, "&lt;")
                     .replace(/>/g, "&gt;")
 
+            // Link straight to the job-approval admin page. If neither SITE_URL nor
+            // appURL is configured we can't build an absolute URL, so fall back to
+            // plain text rather than emit a broken relative Slack link.
+            const base = ($os.getenv("SITE_URL") || $app.settings().meta.appURL || "").replace(/\/+$/, "")
+            const adminUrl = base + "/admin/jobs"
+            const reviewLine = base
+                ? "Review it: <" + adminUrl + "|Job approval admin>"
+                : "Review it: Job approval admin"
+
             const text =
                 ":briefcase: *New job submitted to the board*\n" +
                 "*" + slackEsc(r.getString("title")) + "* at *" + slackEsc(r.getString("company")) + "*\n" +
                 "Salary: " + salary + "\n" +
                 "Submitted by: " + slackEsc(name) + " (" + slackEsc(email) + ")\n" +
                 "Status: " + status + "\n" +
-                "Review it in the admin to approve."
+                reviewLine
 
             const res = $http.send({
                 url: webhook,
@@ -166,16 +175,38 @@ onRecordAfterCreateSuccess((e) => {
                     .replace(/"/g, "&quot;")
                     .replace(/'/g, "&#39;")
 
+            // `description` / `how_to_apply` are rich HTML that jobs_util.sanitizeJobHtml
+            // already cleaned during onRecordCreate, so we embed them as-is to preserve
+            // the poster's formatting — escaping would show raw tags. Every other field
+            // is plain text and gets esc()'d. `name`, `salary` and `esc` are in scope
+            // from the top of this handler.
+            const richField = (field) => {
+                const s = r.getString(field)
+                return s && s.replace(/<[^>]*>/g, "").trim() ? s : "<p>—</p>"
+            }
+
             const message = new MailerMessage({
                 from: { address: settings.meta.senderAddress, name: settings.meta.senderName },
                 to: [{ address: submitter }],
                 subject: "We received your job post: " + r.getString("title"),
                 html:
                     "<h2>Thanks for posting to the IndyHackers job board!</h2>" +
-                    "<p>We received your submission for <strong>" + esc(r.getString("title")) +
-                    "</strong> at <strong>" + esc(r.getString("company")) + "</strong>.</p>" +
-                    "<p>A moderator will review it shortly. You'll get another email with a " +
-                    "management link once it's approved and live on the board.</p>"
+                    "<p>We received your submission. A moderator will review it shortly — you'll " +
+                    "get another email with a management link once it's approved and live on the " +
+                    "board.</p>" +
+                    "<h3>Here's what you submitted</h3>" +
+                    "<ul>" +
+                    "<li><strong>Job title:</strong> " + esc(r.getString("title")) + "</li>" +
+                    "<li><strong>Company:</strong> " + esc(r.getString("company")) + "</li>" +
+                    "<li><strong>Salary:</strong> " + salary + "</li>" +
+                    "<li><strong>Contact name:</strong> " + esc(name) + "</li>" +
+                    "<li><strong>Contact email:</strong> " + esc(submitter) + "</li>" +
+                    "</ul>" +
+                    "<h3>Description</h3>" +
+                    "<div>" + richField("description") + "</div>" +
+                    "<h3>How to apply</h3>" +
+                    "<div>" + richField("how_to_apply") + "</div>" +
+                    "<p>If anything looks off, reply to this email and we'll help you fix it.</p>"
             })
 
             $app.newMailClient().send(message)

--- a/pb/hooks/slack_util.js
+++ b/pb/hooks/slack_util.js
@@ -532,12 +532,12 @@ function notifyBoard(record, autoApproved) {
 const slackEscape = (v) =>
     String(v == null ? "" : v).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
 
-// Best-effort POST of a plain-text message to the configured Slack webhook.
-// No-ops when SLACK_WEBHOOK_URL is unset; never throws (logs on failure) so a
-// notification can't block the DB operation that triggered it.
-function postSlackWebhook(text) {
-    const webhook = $os.getenv("SLACK_WEBHOOK_URL")
+// Best-effort POST of a plain-text message to a Slack incoming webhook. No-ops
+// when the URL is unset; never throws (logs on failure) so a notification can't
+// block the DB operation that triggered it. `label` only tags log lines.
+function sendSlackWebhook(webhook, text, label) {
     if (!webhook) return
+    const tag = label || "webhook"
     try {
         const res = $http.send({
             url: webhook,
@@ -547,11 +547,22 @@ function postSlackWebhook(text) {
             timeout: 15,
         })
         if (res.statusCode < 200 || res.statusCode >= 300) {
-            console.error("[slack] webhook returned " + res.statusCode + ": " + res.raw)
+            console.error("[slack] " + tag + " returned " + res.statusCode + ": " + res.raw)
         }
     } catch (err) {
-        console.error("[slack] webhook post failed: " + err)
+        console.error("[slack] " + tag + " post failed: " + err)
     }
+}
+
+// Private moderator channel — new-job pings, pending-request queue, decisions.
+function postSlackWebhook(text) {
+    sendSlackWebhook($os.getenv("SLACK_WEBHOOK_URL"), text, "webhook")
+}
+
+// Public #jobs channel, seen by all IndyHackers members. Separate webhook so
+// public announcements never leak into the private moderator channel.
+function postJobsChannelWebhook(text) {
+    sendSlackWebhook($os.getenv("SLACK_JOBS_WEBHOOK_URL"), text, "jobs-channel webhook")
 }
 
 // Human-readable identifier for the acting admin from a request event's auth
@@ -600,6 +611,7 @@ module.exports = {
     notifyBoard,
     slackEscape,
     postSlackWebhook,
+    postJobsChannelWebhook,
     adminLabel,
     notifyInviteDecision,
 }

--- a/src/components/TipTapEditor.vue
+++ b/src/components/TipTapEditor.vue
@@ -147,6 +147,9 @@ export default {
 .tiptap-editor-wrapper {
   border-radius: 5px;
   border: 1px solid color-mix(in srgb, var(--border) 30%, var(--surface-1));
+  /* Solid surface so the editable area stays legible even when the page
+     background behind it is tinted (e.g. the manage page's --surface-2). */
+  background: var(--surface-1);
   transition: border-color 0.3s ease;
   overflow: hidden;
 }
@@ -203,5 +206,16 @@ export default {
 
 :deep(.tiptap-editor) {
   padding: 1rem;
+}
+
+/* Base typography for the editable content, shared by every consumer.
+   `outline: none` drops the browser's contenteditable focus ring — the
+   wrapper's :focus-within box-shadow is the focus affordance instead. */
+:deep(.tiptap) {
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--bs-body-color);
+  outline: none;
 }
 </style>

--- a/src/components/TipTapEditor.vue
+++ b/src/components/TipTapEditor.vue
@@ -1,5 +1,95 @@
 <template>
-  <editor-content :editor="editor" class="tiptap-editor" />
+  <div class="tiptap-editor-wrapper">
+    <div v-if="editor" class="tiptap-toolbar">
+      <button
+        type="button"
+        class="toolbar-btn"
+        :class="{ 'is-active': editor.isActive('bold') }"
+        title="Bold"
+        aria-label="Bold"
+        @click="editor.chain().focus().toggleBold().run()"
+      >
+        <IMdiFormatBold />
+      </button>
+      <button
+        type="button"
+        class="toolbar-btn"
+        :class="{ 'is-active': editor.isActive('italic') }"
+        title="Italic"
+        aria-label="Italic"
+        @click="editor.chain().focus().toggleItalic().run()"
+      >
+        <IMdiFormatItalic />
+      </button>
+      <button
+        type="button"
+        class="toolbar-btn"
+        :class="{ 'is-active': editor.isActive('strike') }"
+        title="Strikethrough"
+        aria-label="Strikethrough"
+        @click="editor.chain().focus().toggleStrike().run()"
+      >
+        <IMdiFormatStrikethrough />
+      </button>
+
+      <span class="toolbar-divider" aria-hidden="true"></span>
+
+      <button
+        type="button"
+        class="toolbar-btn"
+        :class="{ 'is-active': editor.isActive('heading', { level: 2 }) }"
+        title="Heading"
+        aria-label="Heading"
+        @click="editor.chain().focus().toggleHeading({ level: 2 }).run()"
+      >
+        <IMdiFormatHeader2 />
+      </button>
+      <button
+        type="button"
+        class="toolbar-btn"
+        :class="{ 'is-active': editor.isActive('heading', { level: 3 }) }"
+        title="Subheading"
+        aria-label="Subheading"
+        @click="editor.chain().focus().toggleHeading({ level: 3 }).run()"
+      >
+        <IMdiFormatHeader3 />
+      </button>
+
+      <span class="toolbar-divider" aria-hidden="true"></span>
+
+      <button
+        type="button"
+        class="toolbar-btn"
+        :class="{ 'is-active': editor.isActive('bulletList') }"
+        title="Bullet list"
+        aria-label="Bullet list"
+        @click="editor.chain().focus().toggleBulletList().run()"
+      >
+        <IMdiFormatListBulleted />
+      </button>
+      <button
+        type="button"
+        class="toolbar-btn"
+        :class="{ 'is-active': editor.isActive('orderedList') }"
+        title="Numbered list"
+        aria-label="Numbered list"
+        @click="editor.chain().focus().toggleOrderedList().run()"
+      >
+        <IMdiFormatListNumbered />
+      </button>
+      <button
+        type="button"
+        class="toolbar-btn"
+        :class="{ 'is-active': editor.isActive('blockquote') }"
+        title="Quote"
+        aria-label="Quote"
+        @click="editor.chain().focus().toggleBlockquote().run()"
+      >
+        <IMdiFormatQuoteClose />
+      </button>
+    </div>
+    <editor-content :editor="editor" class="tiptap-editor" />
+  </div>
 </template>
 
 <script>
@@ -22,6 +112,8 @@ export default {
 
   data() {
     return {
+      // Left deeply reactive on purpose: it lets the toolbar's `editor.isActive(...)`
+      // states re-render as the selection/formatting changes.
       editor: null
     }
   },
@@ -52,16 +144,64 @@ export default {
 
 <style scoped>
 /* TipTap Editor */
-:deep(.tiptap-editor) {
+.tiptap-editor-wrapper {
   border-radius: 5px;
-  padding: 1rem;
   border: 1px solid color-mix(in srgb, var(--border) 30%, var(--surface-1));
-  box-shadow: none;
   transition: border-color 0.3s ease;
+  overflow: hidden;
 }
 
-:deep(.tiptap-editor:focus) {
+.tiptap-editor-wrapper:focus-within {
   border-color: var(--focus-ring);
   box-shadow: 0 0 8px color-mix(in srgb, var(--focus-ring) 20%, transparent);
+}
+
+.tiptap-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.15rem;
+  padding: 0.35rem 0.5rem;
+  background: var(--surface-2);
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 30%, var(--surface-1));
+}
+
+.toolbar-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.9rem;
+  height: 1.9rem;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.toolbar-btn:hover {
+  background: color-mix(in srgb, var(--text-primary) 10%, transparent);
+  color: var(--text-primary);
+}
+
+.toolbar-btn.is-active {
+  background: color-mix(in srgb, var(--focus-ring) 20%, transparent);
+  color: var(--text-primary);
+}
+
+.toolbar-divider {
+  width: 1px;
+  align-self: stretch;
+  margin: 0.2rem 0.25rem;
+  background: color-mix(in srgb, var(--border) 40%, transparent);
+}
+
+:deep(.tiptap-editor) {
+  padding: 1rem;
 }
 </style>

--- a/src/components/admin/JobApprovals.vue
+++ b/src/components/admin/JobApprovals.vue
@@ -4,7 +4,7 @@
       <AdminBar />
       <h1>Job approvals</h1>
       <p class="job-admin__sub">
-        Jobs submitted to the board that are waiting to be published. Approve to make a
+        Jobs submitted in the last 60 days that are waiting to be published. Approve to make a
         listing live, or reject to remove it.
       </p>
 
@@ -92,16 +92,23 @@ const salary = (job) => {
   return fmt(job.salary_min) + ' – ' + fmt(job.salary_max)
 }
 
+// Only surface recent submissions. Stale, never-approved rows pile up in the
+// database and aren't worth reviewing, so hide anything older than this.
+const REVIEW_WINDOW_DAYS = 60
+
 const load = async () => {
   loading.value = true
   authError.value = false
   try {
+    const cutoff = new Date(Date.now() - REVIEW_WINDOW_DAYS * 24 * 60 * 60 * 1000)
     const res = await pocketbase.collection('jobs').getList(1, 100, {
-      filter: 'approved = false',
+      // filter() safely interpolates the Date into PocketBase's datetime format.
+      filter: pocketbase.filter('approved = false && created >= {:cutoff}', { cutoff }),
       sort: '-created'
     })
-    // Safety net: keep only unapproved (in case the backend ignores the filter).
-    jobs.value = res.items.filter((j) => !j.approved)
+    // Safety net: keep only unapproved rows from within the review window (in
+    // case the backend ignores the filter).
+    jobs.value = res.items.filter((j) => !j.approved && new Date(j.created) >= cutoff)
   } catch (err) {
     if (err?.status === 401 || err?.status === 403) {
       authError.value = true

--- a/src/components/jobs/CreateJobView.vue
+++ b/src/components/jobs/CreateJobView.vue
@@ -252,16 +252,8 @@ export default defineComponent({
   text-align: right;
 }
 
-/* The editor's outer border/background now lives on TipTapEditor's own wrapper;
-   here we only set typography and remove the default ProseMirror focus outline. */
-:deep(.tiptap) {
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: var(--bs-body-color);
-  outline: none;
-}
-
+/* The editor's border, background and base typography now live in
+   TipTapEditor's own styles; here we only size the two fields. */
 :deep(.tip-tap-description .tiptap.ProseMirror) {
   min-height: 150px;
 }

--- a/src/components/jobs/CreateJobView.vue
+++ b/src/components/jobs/CreateJobView.vue
@@ -252,25 +252,14 @@ export default defineComponent({
   text-align: right;
 }
 
+/* The editor's outer border/background now lives on TipTapEditor's own wrapper;
+   here we only set typography and remove the default ProseMirror focus outline. */
 :deep(.tiptap) {
-  display: block;
-  width: 100%;
-  padding: 0.375rem 0.75rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5;
   color: var(--bs-body-color);
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  background-color: var(--bs-body-bg);
-  background-clip: padding-box;
-  border: var(--bs-border-width) solid var(--bs-border-color);
-  border-radius: var(--bs-border-radius);
-  transition:
-    border-color 0.15s ease-in-out,
-    box-shadow 0.15s ease-in-out;
-  margin-bottom: 1rem;
+  outline: none;
 }
 
 :deep(.tip-tap-description .tiptap.ProseMirror) {

--- a/src/components/jobs/ManageJobView.vue
+++ b/src/components/jobs/ManageJobView.vue
@@ -1,84 +1,88 @@
 <template>
   <div class="manage-job">
     <div class="ih-container">
-      <h1 class="title">Manage Your Job Post</h1>
+      <div class="manage-job-content">
+        <h1 class="title">Manage Your Job Post</h1>
 
-      <b-alert :model-value="!!error" variant="danger">{{ error }}</b-alert>
-      <b-alert v-model="notice.visible" :variant="notice.variant" dismissable>{{
-        notice.message
-      }}</b-alert>
+        <b-alert :model-value="!!error" variant="danger">{{ error }}</b-alert>
+        <b-alert v-model="notice.visible" :variant="notice.variant" dismissable>{{
+          notice.message
+        }}</b-alert>
 
-      <p v-if="loading" class="subtitle">Loading…</p>
+        <p v-if="loading" class="subtitle">Loading…</p>
 
-      <div v-else-if="job">
-        <b-alert :model-value="job.filled" variant="warning">
-          This post is marked as <strong>filled</strong> and is hidden from the public job board.
-        </b-alert>
+        <div v-else-if="job">
+          <b-card class="form-card">
+            <b-alert :model-value="job.filled" variant="warning">
+              This post is marked as <strong>filled</strong> and is hidden from the public job board.
+            </b-alert>
 
-        <b-form @submit.prevent="save">
-          <b-row>
-            <b-col md="6">
-              <b-form-group label="Job Title" label-for="input-title">
-                <b-form-input id="input-title" v-model="formData.title" required></b-form-input>
-              </b-form-group>
-            </b-col>
-            <b-col md="6">
-              <b-form-group label="Company" label-for="input-company">
-                <b-form-input id="input-company" v-model="formData.company" required></b-form-input>
-              </b-form-group>
-            </b-col>
-          </b-row>
+            <b-form @submit.prevent="save">
+              <b-row>
+                <b-col md="6">
+                  <b-form-group label="Job Title" label-for="input-title">
+                    <b-form-input id="input-title" v-model="formData.title" required></b-form-input>
+                  </b-form-group>
+                </b-col>
+                <b-col md="6">
+                  <b-form-group label="Company" label-for="input-company">
+                    <b-form-input id="input-company" v-model="formData.company" required></b-form-input>
+                  </b-form-group>
+                </b-col>
+              </b-row>
 
-          <b-row class="mt-3">
-            <b-form-group label="Salary Range (Optional)" class="w-100">
-              <div class="d-flex align-items-center">
-                <b-input-group append="K" class="w-auto" style="max-width: 120px;">
-                  <b-form-input type="number" id="input-salary-min" v-model="formData.salary_min" :min="0" :max="1000"></b-form-input>
-                </b-input-group>
-                <span class="mx-2">-</span>
-                <b-input-group append="K" class="w-auto" style="max-width: 120px;">
-                  <b-form-input type="number" id="input-salary-max" v-model="formData.salary_max" :min="0" :max="1000"></b-form-input>
-                </b-input-group>
-              </div>
-            </b-form-group>
-          </b-row>
+              <b-row class="mt-3">
+                <b-form-group label="Salary Range (Optional)" class="w-100">
+                  <div class="d-flex align-items-center">
+                    <b-input-group append="K" class="w-auto" style="max-width: 120px;">
+                      <b-form-input type="number" id="input-salary-min" v-model="formData.salary_min" :min="0" :max="1000"></b-form-input>
+                    </b-input-group>
+                    <span class="mx-2">-</span>
+                    <b-input-group append="K" class="w-auto" style="max-width: 120px;">
+                      <b-form-input type="number" id="input-salary-max" v-model="formData.salary_max" :min="0" :max="1000"></b-form-input>
+                    </b-input-group>
+                  </div>
+                </b-form-group>
+              </b-row>
 
-          <b-row class="mt-3">
-            <b-col cols="12">
-              <b-form-group label="Description">
-                <tip-tap-editor class="tip-tap-description" v-model="formData.description" />
-              </b-form-group>
-            </b-col>
-          </b-row>
-          <b-row class="mt-3">
-            <b-col cols="12">
-              <b-form-group label="How to Apply">
-                <tip-tap-editor class="tip-tap-how-to-apply" v-model="formData.how_to_apply" />
-              </b-form-group>
-            </b-col>
-          </b-row>
+              <b-row class="mt-3">
+                <b-col cols="12">
+                  <b-form-group label="Description">
+                    <tip-tap-editor class="tip-tap-description" v-model="formData.description" />
+                  </b-form-group>
+                </b-col>
+              </b-row>
+              <b-row class="mt-3">
+                <b-col cols="12">
+                  <b-form-group label="How to Apply">
+                    <tip-tap-editor class="tip-tap-how-to-apply" v-model="formData.how_to_apply" />
+                  </b-form-group>
+                </b-col>
+              </b-row>
 
-          <b-row class="mt-3">
-            <b-col cols="12" class="d-flex justify-content-between">
-              <b-button
-                v-if="!job.filled"
-                variant="outline-danger"
-                type="button"
-                :disabled="saving"
-                @click="markFilled"
-              >Mark as filled / take down</b-button>
-              <b-button
-                v-else
-                variant="outline-secondary"
-                type="button"
-                :disabled="saving"
-                @click="relist"
-              >Re-list this job</b-button>
+              <b-row class="mt-3">
+                <b-col cols="12" class="d-flex justify-content-between">
+                  <b-button
+                    v-if="!job.filled"
+                    variant="outline-danger"
+                    type="button"
+                    :disabled="saving"
+                    @click="markFilled"
+                  >Mark as filled / take down</b-button>
+                  <b-button
+                    v-else
+                    variant="outline-secondary"
+                    type="button"
+                    :disabled="saving"
+                    @click="relist"
+                  >Re-list this job</b-button>
 
-              <b-button variant="primary" type="submit" :disabled="saving">Save changes</b-button>
-            </b-col>
-          </b-row>
-        </b-form>
+                  <b-button variant="primary" type="submit" :disabled="saving">Save changes</b-button>
+                </b-col>
+              </b-row>
+            </b-form>
+          </b-card>
+        </div>
       </div>
     </div>
   </div>
@@ -214,6 +218,16 @@ export default defineComponent({
 .manage-job {
   background-color: var(--surface-2);
   padding: 3rem 0;
+}
+.manage-job-content {
+  max-width: 800px;
+  margin: 0 auto;
+}
+.form-card {
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border) !important;
+  background: var(--surface-1) !important;
+  padding: 2rem;
 }
 .title {
   font-size: clamp(2rem, 4vw, 3rem);


### PR DESCRIPTION
Five related job-board improvements, all branched off `dev`.

### 1. Rich-text toolbar on the submit-a-job form
The Description and How-to-Apply fields already used a TipTap editor, but it had **no toolbar** — posters had no visible way to style their posting (only keyboard shortcuts). Added a formatting toolbar (bold / italic / strikethrough, H2 / H3, bullet & numbered lists, quote) shared by both fields. Reconciled `CreateJobView` styles so the editor is a single bordered container (toolbar + content) instead of a doubled input box.

### 2. Confirmation email echoes the full submission
The "we received your job post" email to the poster now includes everything they submitted — title, company, salary, contact name/email, and the rich-text **Description** and **How to Apply** (rendered from the HTML that `sanitizeJobHtml` already cleaned on create, so formatting is preserved and it's XSS-safe).

### 3. Moderator Slack notification links to the approval page
Changed the new-job Slack webhook line from `Review it in the admin to approve.` to **`Review it: Job approval admin`**, linked to `/admin/jobs`. Falls back to plain text if neither `SITE_URL` nor `appURL` is configured.

### 4. Job approvals: last 60 days only
Old, never-approved rows were cluttering the queue. The admin page now filters to submissions `created` within the last 60 days (server-side PocketBase filter + a client-side safety net mirroring the existing one).

### 5. Announce approved jobs to the public #jobs channel
When a job is approved (`approved` false→true), post to the **public #jobs Slack channel** so members see the opening: title, company, and a direct link to the `/job?id=<id>` posting. Uses a **separate** `SLACK_JOBS_WEBHOOK_URL` so public announcements never post to the private moderator channel; the webhook POST logic is factored into a shared `sendSlackWebhook` helper. Independent/best-effort, and skips when no absolute base URL is configured. Documented in `.env.example`.

> **Deploy note:** #5 requires setting `SLACK_JOBS_WEBHOOK_URL` (an incoming webhook pointed at #jobs) on the PocketBase container. Until it's set, approvals simply won't announce — nothing else is affected.

## Testing
- `vite build` passes; icons resolve.
- `pb/hooks/jobs.pb.js` and `pb/hooks/slack_util.js` pass `node --check`.
- Test suite: the 4 failing specs (`CalendarEvents`, `HelloWorld`, `LoginPage`, `SignupPage`) fail identically on `dev` **without** these changes — pre-existing and unrelated (CalendarEvents is the date bug fixed separately in #117). All jobs-related tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)