### PR TITLE
Job postings: 60-day expiry with self-service extend + reminders

### DIFF
--- a/pb/hooks/jobs.pb.js
+++ b/pb/hooks/jobs.pb.js
@@ -46,8 +46,10 @@ onRecordUpdate((e) => {
     const isApproved = e.record.getBool("approved")
 
     if (!wasApproved && isApproved) {
-        // approved just flipped to true — stamp the time
+        // approved just flipped to true — stamp the time and start a fresh
+        // 60-day posting period (so the expiry-reminder cron can fire again).
         e.record.set("approved_at", new Date().toISOString())
+        e.record.set("expiry_reminder_sent", false)
     } else if (wasApproved && !isApproved) {
         // approved flipped back to false — clear the timestamp
         e.record.set("approved_at", "")
@@ -255,6 +257,10 @@ onRecordAfterUpdateSuccess((e) => {
                     "<p>Need to make a change, or has the role been filled? Use your private " +
                     "management link to edit the post or take it down:</p>" +
                     '<p><a href="' + manageUrl + '">' + manageUrl + "</a></p>" +
+                    "<p>Your posting will stay on the board for <strong>60 days</strong>. " +
+                    "Still hiring when that's up? Open the link above and click " +
+                    "<strong>Extend for 60 days</strong> to keep it live — you can do this as " +
+                    "many times as you need.</p>" +
                     "<p>Keep this email — anyone with that link can manage the post.</p>"
             })
 

--- a/pb/hooks/jobs_expiry.js
+++ b/pb/hooks/jobs_expiry.js
@@ -1,0 +1,130 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+// Emails job posters a heads-up ~10 days before their posting drops off the
+// board, with instructions and their edit link so they can extend it.
+//
+// Expiry model: the public list shows a job while `approved_at` is within the
+// last POSTING_DAYS days (see src/components/jobs/JobsList.vue and the manage
+// "Extend for 60 days" action), so a posting expires POSTING_DAYS after its
+// approval date. We remind once, REMIND_BEFORE_DAYS before that.
+//
+// Idempotent: `expiry_reminder_sent` is flipped true before the email goes out,
+// and reset to false whenever the job is (re)approved or extended (jobs.pb.js /
+// jobs_manage.pb.js) so each posting period gets exactly one reminder.
+//
+// Runs inside the PocketBase JSVM (see jobs_expiry.pb.js for the cron).
+
+const POSTING_DAYS = 60
+const REMIND_BEFORE_DAYS = 10
+const DAY_MS = 24 * 60 * 60 * 1000
+const MONTHS = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December"
+]
+
+// Parse a PocketBase datetime ("2026-06-14 12:00:00.000Z") into a JS Date.
+// Replacing the space with "T" keeps goja's Date parser happy.
+function toDate(value) {
+  if (!value) return null
+  const d = new Date(String(value).replace(" ", "T"))
+  return isNaN(d.getTime()) ? null : d
+}
+
+function formatDate(d) {
+  return MONTHS[d.getUTCMonth()] + " " + d.getUTCDate() + ", " + d.getUTCFullYear()
+}
+
+function sendExpiryEmail(job) {
+  const submitter = job.getString("email")
+  if (!submitter) return false
+
+  const approvedAt = toDate(job.getString("approved_at"))
+  if (!approvedAt) return false
+  const expiresOn = new Date(approvedAt.getTime() + POSTING_DAYS * DAY_MS)
+
+  const settings = $app.settings()
+  const base = ($os.getenv("SITE_URL") || settings.meta.appURL || "").replace(/\/+$/, "")
+  if (!base) {
+    console.warn("[jobs] no SITE_URL/appURL; skipping expiry reminder for " + job.id)
+    return false
+  }
+  const manageUrl = base + "/jobs/manage?token=" + job.getString("edit_token")
+
+  const esc = (v) =>
+    String(v == null ? "" : v)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;")
+
+  const message = new MailerMessage({
+    from: { address: settings.meta.senderAddress, name: settings.meta.senderName },
+    to: [{ address: submitter }],
+    subject: "Your job post expires soon: " + job.getString("title"),
+    html:
+      "<h2>Your job post is expiring soon</h2>" +
+      "<p><strong>" + esc(job.getString("title")) + "</strong> at <strong>" +
+      esc(job.getString("company")) + "</strong> is scheduled to come down from the " +
+      "IndyHackers job board on <strong>" + formatDate(expiresOn) + "</strong> " +
+      "(about " + REMIND_BEFORE_DAYS + " days from now).</p>" +
+      "<p>Still hiring? Open your management link and click " +
+      "<strong>Extend for 60 days</strong> to keep it live for another " +
+      POSTING_DAYS + " days:</p>" +
+      '<p><a href="' + manageUrl + '">' + manageUrl + "</a></p>" +
+      "<p>No longer hiring? You can ignore this — the post will be removed " +
+      "automatically. Keep this email; anyone with that link can manage the post.</p>"
+  })
+
+  $app.newMailClient().send(message)
+  return true
+}
+
+function sendExpiryReminders() {
+  const now = new Date()
+
+  // A posting expires POSTING_DAYS after approved_at. Remind once it is within
+  // REMIND_BEFORE_DAYS of that, but before it has expired:
+  //   approved_at <= now - (POSTING_DAYS - REMIND_BEFORE_DAYS)   (remind point reached)
+  //   approved_at >  now - POSTING_DAYS                          (still live)
+  const remindAfter = new Date(now.getTime() - (POSTING_DAYS - REMIND_BEFORE_DAYS) * DAY_MS).toISOString()
+  const stillLive = new Date(now.getTime() - POSTING_DAYS * DAY_MS).toISOString()
+
+  let candidates = []
+  try {
+    candidates = $app.findRecordsByFilter(
+      "jobs",
+      'approved = true && filled != true && expiry_reminder_sent != true && ' +
+        'approved_at != "" && approved_at <= {:remindAfter} && approved_at > {:stillLive}',
+      "+approved_at",
+      200,
+      0,
+      { remindAfter, stillLive }
+    )
+  } catch (err) {
+    console.error("[jobs] expiry-reminder query failed: " + err)
+    return 0
+  }
+
+  let sent = 0
+  candidates.forEach((job) => {
+    try {
+      // Claim first: flip the flag and persist before sending, so a crash mid-run
+      // can't double-send. approved is unchanged, so approved_at is preserved.
+      job.set("expiry_reminder_sent", true)
+      $app.save(job)
+
+      if (sendExpiryEmail(job)) {
+        sent += 1
+        console.log("[jobs] expiry reminder sent for " + job.id)
+      }
+    } catch (err) {
+      console.error("[jobs] expiry reminder for " + job.id + " failed: " + err)
+    }
+  })
+
+  console.log("[jobs] sent " + sent + " expiry reminder(s)")
+  return sent
+}
+
+module.exports = { sendExpiryReminders }

--- a/pb/hooks/jobs_expiry.pb.js
+++ b/pb/hooks/jobs_expiry.pb.js
@@ -1,0 +1,25 @@
+/// <reference path="../pb_data/types.d.ts" />
+
+// Once a day, email posters whose job is ~10 days from dropping off the board,
+// nudging them to extend it. Logic lives in jobs_expiry.js. Also exposes a
+// `send-job-expiry-reminders` console command for manual runs / testing.
+
+cronAdd("send-job-expiry-reminders", "0 14 * * *", () => {
+  try {
+    const jobsExpiry = require(`${__hooks}/jobs_expiry.js`)
+    jobsExpiry.sendExpiryReminders()
+  } catch (err) {
+    console.error("[jobs] expiry-reminder cron failed: " + err)
+  }
+})
+
+$app.rootCmd.addCommand(
+  new Command({
+    use: "send-job-expiry-reminders",
+    run: (cmd, args) => {
+      const jobsExpiry = require(`${__hooks}/jobs_expiry.js`)
+      const sent = jobsExpiry.sendExpiryReminders()
+      console.log("sent " + sent + " expiry reminder(s)")
+    }
+  })
+)

--- a/pb/hooks/jobs_manage.pb.js
+++ b/pb/hooks/jobs_manage.pb.js
@@ -18,7 +18,10 @@ routerAdd("GET", "/api/jobs/manage/{token}", (e) => {
         description: r.getString("description"),
         how_to_apply: r.getString("how_to_apply"),
         approved: r.getBool("approved"),
-        filled: r.getBool("filled")
+        filled: r.getBool("filled"),
+        // Drives the "expires on / extend" UI on the manage page. The public
+        // list hides a job 60 days after approved_at, so that's its expiry.
+        approved_at: r.getString("approved_at")
     })
 
     const token = e.request.pathValue("token")
@@ -48,7 +51,10 @@ routerAdd("PATCH", "/api/jobs/manage/{token}", (e) => {
         description: r.getString("description"),
         how_to_apply: r.getString("how_to_apply"),
         approved: r.getBool("approved"),
-        filled: r.getBool("filled")
+        filled: r.getBool("filled"),
+        // Drives the "expires on / extend" UI on the manage page. The public
+        // list hides a job 60 days after approved_at, so that's its expiry.
+        approved_at: r.getString("approved_at")
     })
 
     const token = e.request.pathValue("token")
@@ -67,8 +73,10 @@ routerAdd("PATCH", "/api/jobs/manage/{token}", (e) => {
     const body = e.requestInfo().body || {}
 
     // Editable text/number fields (only those actually provided).
+    let edited = false
     for (const key of EDITABLE) {
         if (body[key] === undefined) continue
+        edited = true
 
         if (key === "salary_min" || key === "salary_max") {
             const n = Number(body[key])
@@ -101,6 +109,54 @@ routerAdd("PATCH", "/api/jobs/manage/{token}", (e) => {
         job.set("filled", !!body.filled)
     }
 
+    // "Extend for 60 days": reset approved_at to now so the 60-day visibility
+    // window (JobsList's approved_at >= now-60d filter) restarts. Only an
+    // already-approved, live posting can be extended. Resetting the reminder
+    // flag lets the expiry-reminder cron fire again for the new period.
+    if (body.extend === true) {
+        if (!job.getBool("approved")) {
+            throw new BadRequestError("Only an approved, live posting can be extended.")
+        }
+        job.set("approved_at", new Date().toISOString())
+        job.set("expiry_reminder_sent", false)
+    }
+
     $app.save(job)
+
+    // Tell the moderator channel (SLACK_WEBHOOK_URL) when a poster self-manages
+    // their post via the edit link. Best-effort — postSlackWebhook no-ops with no
+    // webhook and never throws, but guard the require/build too so a notification
+    // failure can never fail the poster's edit. Extend/take-down/re-list are
+    // mutually exclusive from the frontend; classify by priority just in case.
+    let action = null
+    let emoji = ":pencil2:"
+    if (body.extend === true) {
+        action = "extended for 60 days"
+        emoji = ":calendar:"
+    } else if (body.filled === true) {
+        action = "taken down"
+        emoji = ":outbox_tray:"
+    } else if (body.filled === false) {
+        action = "re-listed"
+        emoji = ":inbox_tray:"
+    } else if (edited) {
+        action = "edited"
+        emoji = ":pencil2:"
+    }
+    if (action) {
+        try {
+            const util = require(`${__hooks}/slack_util.js`)
+            const esc = util.slackEscape
+            const base = ($os.getenv("SITE_URL") || $app.settings().meta.appURL || "").replace(/\/+$/, "")
+            const link = base ? "\n<" + base + "/job?id=" + job.id + "|View posting>" : ""
+            util.postSlackWebhook(
+                emoji + " *Job " + action + " by the poster*\n" +
+                "*" + esc(job.getString("title")) + "* at *" + esc(job.getString("company")) + "*" + link
+            )
+        } catch (err) {
+            console.error("[jobs] manage webhook failed: " + err)
+        }
+    }
+
     return e.json(200, publicView(job))
 })

--- a/pb/migrations/030_add_expiry_reminder_sent_to_jobs.js
+++ b/pb/migrations/030_add_expiry_reminder_sent_to_jobs.js
@@ -1,0 +1,26 @@
+/// <reference path="../pb_data/types.d.ts" />
+migrate((app) => {
+  const collection = app.findCollectionByNameOrId("pbc_2409499253")
+
+  // Idempotency guard for the expiry-reminder cron (pb/hooks/jobs_expiry.js):
+  // set true once the "expires in 10 days" email has been sent for the current
+  // posting period, and reset to false whenever the posting is (re)approved or
+  // extended so the next period gets its own reminder.
+  collection.fields.addAt(52, new Field({
+    "hidden": false,
+    "id": "bool_expiry_reminder_sent",
+    "name": "expiry_reminder_sent",
+    "presentable": false,
+    "required": false,
+    "system": false,
+    "type": "bool"
+  }))
+
+  app.save(collection)
+}, (app) => {
+  const collection = app.findCollectionByNameOrId("pbc_2409499253")
+
+  collection.fields.removeById("bool_expiry_reminder_sent")
+
+  return app.save(collection)
+})

--- a/src/components/__tests__/ManageJobView.spec.js
+++ b/src/components/__tests__/ManageJobView.spec.js
@@ -11,7 +11,9 @@ const mockJob = {
   description: '<p>Great opportunity</p>',
   how_to_apply: '<p>Email hr@acme.com</p>',
   approved: true,
-  filled: false
+  filled: false,
+  // ~50 days ago → expiry ~10 days out, so the expiry note + Extend button show.
+  approved_at: new Date(Date.now() - 50 * 24 * 60 * 60 * 1000).toISOString()
 }
 
 function createMockPocketBase(send) {
@@ -110,6 +112,27 @@ describe('ManageJobView', () => {
       expect.objectContaining({ method: 'PATCH', body: { filled: true } })
     )
     confirmSpy.mockRestore()
+  })
+
+  it('shows the expiry date and extends the posting for 60 days', async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({ ...mockJob })
+      .mockResolvedValueOnce({ ...mockJob, approved_at: new Date().toISOString() })
+    const wrapper = mountView(createMockPocketBase(send))
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('This posting is live until')
+
+    const extendBtn = wrapper.findAll('button').find((b) => b.text().includes('Extend for 60 days'))
+    expect(extendBtn).toBeTruthy()
+    await extendBtn.trigger('click')
+    await flushPromises()
+
+    expect(send).toHaveBeenLastCalledWith(
+      '/api/jobs/manage/tok123',
+      expect.objectContaining({ method: 'PATCH', body: { extend: true } })
+    )
   })
 
   it('does not take down the job if confirmation is cancelled', async () => {

--- a/src/components/jobs/ManageJobView.vue
+++ b/src/components/jobs/ManageJobView.vue
@@ -60,6 +60,24 @@
                 </b-col>
               </b-row>
 
+              <b-row class="mt-3" v-if="job.approved && !job.filled && expiresLabel">
+                <b-col cols="12">
+                  <div class="expiry-note">
+                    <p class="expiry-note__text">
+                      This posting is live until <strong>{{ expiresLabel }}</strong>, after which
+                      it's automatically taken down from the board. Still hiring? Extend it to keep
+                      it live for another 60 days.
+                    </p>
+                    <b-button
+                      variant="outline-secondary"
+                      type="button"
+                      :disabled="saving"
+                      @click="extend"
+                    >Extend for 60 days</b-button>
+                  </div>
+                </b-col>
+              </b-row>
+
               <b-row class="mt-3">
                 <b-col cols="12" class="d-flex justify-content-between">
                   <b-button
@@ -111,6 +129,17 @@ export default defineComponent({
         how_to_apply: ''
       },
       notice: { message: '', visible: false, variant: 'success' }
+    }
+  },
+  computed: {
+    // The board hides a job 60 days after its approval date, so that's when it
+    // expires. Null until we have an approved job with an approved_at.
+    expiresLabel() {
+      if (!this.job || !this.job.approved || !this.job.approved_at) return null
+      const d = new Date(String(this.job.approved_at).replace(' ', 'T'))
+      if (Number.isNaN(d.getTime())) return null
+      d.setDate(d.getDate() + 60)
+      return d.toLocaleDateString(undefined, { year: 'numeric', month: 'long', day: 'numeric' })
     }
   },
   methods: {
@@ -199,6 +228,9 @@ export default defineComponent({
     async relist() {
       await this.patch({ filled: false }, 'Your job has been re-listed.')
     },
+    async extend() {
+      await this.patch({ extend: true }, 'Your posting has been extended for another 60 days.')
+    },
     showNotice(message, variant) {
       this.notice = { message, visible: true, variant }
       try {
@@ -228,6 +260,17 @@ export default defineComponent({
   border: 1px solid var(--border) !important;
   background: var(--surface-1) !important;
   padding: 2rem;
+}
+.expiry-note {
+  border: 1px solid color-mix(in srgb, var(--border) 30%, var(--surface-1));
+  border-radius: var(--radius-md, 8px);
+  background: var(--surface-2);
+  padding: 1rem 1.25rem;
+}
+.expiry-note__text {
+  margin: 0 0 0.75rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
 }
 .title {
   font-size: clamp(2rem, 4vw, 3rem);

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -33,7 +33,10 @@ let manageJob = {
   description: '<p>Build delightful UIs with Vue.</p>',
   how_to_apply: '<p>Email jobs@sample.co</p>',
   approved: true,
-  filled: false
+  filled: false,
+  // ~53 days ago, so the manage page shows an expiry ~7 days out.
+  approved_at: new Date(Date.now() - 53 * 24 * 60 * 60 * 1000).toISOString(),
+  expiry_reminder_sent: false
 }
 
 export const handlers = [
@@ -239,7 +242,16 @@ export const handlers = [
   }),
   http.patch('/api/jobs/manage/:token', async ({ request }) => {
     const body = JSON.parse(await request.text())
-    manageJob = { ...manageJob, ...body }
+    if (body.extend) {
+      // Mirror the backend: extending resets the 60-day clock.
+      manageJob = {
+        ...manageJob,
+        approved_at: new Date().toISOString(),
+        expiry_reminder_sent: false
+      }
+    } else {
+      manageJob = { ...manageJob, ...body }
+    }
     return HttpResponse.json(manageJob)
   })
 ]


### PR DESCRIPTION
Makes the job-board's 60-day posting lifecycle explicit and self-serviceable. The public list already hides a job 60 days after its approval date (`JobsList` filters `approved_at >= now-60d`); this builds the surrounding UX on top of that.

### Manage page — expiry text + "Extend for 60 days"
The manage form now shows when the post expires ("This posting is live until **&lt;date&gt;**…") and adds an **Extend for 60 days** button (shown only for approved, live posts). Extending resets `approved_at` to now, restarting the 60-day window.

### Backend `extend` action
New `extend` branch on the `PATCH /api/jobs/manage/{token}` endpoint: resets `approved_at` (and clears the reminder flag). Only an already-approved, live post can be extended. `approved_at` is now exposed through the manage endpoint to drive the UI.

### Approval email
The "your job is live" email now notes the 60-day duration and how to extend via the edit link.

### Expiry-reminder cron (`jobs_expiry.js` / `.pb.js`)
Runs once a day and emails posters ~10 days before expiry with extend instructions and their edit link. Idempotent via a new `expiry_reminder_sent` flag (**migration 030**), reset on (re)approval and on extend so each period gets exactly one reminder. Also adds a `send-job-expiry-reminders` console command for manual runs.

### Moderator Slack notifications
Posts to `SLACK_WEBHOOK_URL` when a poster takes down, re-lists, edits, or extends their post via the manage link (distinct emoji per action + a link to the posting).

## Notes
- **Deploy:** adds a DB field, so migration `030` runs on the next PocketBase start. No new env vars (reuses `SITE_URL`/`appURL` and `SLACK_WEBHOOK_URL`).
- **Extend semantics:** because the board hides a job 60 days after `approved_at`, extending resets that date to *now* — i.e. 60 more days from today (matching the button label).

## Testing
- All hooks pass `node --check`; `vite build` passes.
- 15 targeted tests pass, including a new one asserting the expiry text renders and Extend PATCHes `{ extend: true }`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)