### PR TITLE
Add Terms of Service and Privacy Policy links to footer

### DIFF
--- a/src/components/BottomLinkTree.vue
+++ b/src/components/BottomLinkTree.vue
@@ -2,7 +2,11 @@
   <footer class="ih-footer">
     <div class="ih-container ih-footer__inner">
       <p class="ih-footer__copy">&copy; {{ year }} Indy Hackers — made with love by volunteers</p>
-      <RouterLink to="/code-of-conduct" class="ih-footer__coc">Code of Conduct</RouterLink>
+      <nav class="ih-footer__links">
+        <RouterLink to="/code-of-conduct" class="ih-footer__link">Code of Conduct</RouterLink>
+        <RouterLink to="/terms" class="ih-footer__link">Terms of Service</RouterLink>
+        <RouterLink to="/privacy" class="ih-footer__link">Privacy Policy</RouterLink>
+      </nav>
     </div>
   </footer>
 </template>
@@ -39,14 +43,21 @@ export default {
   font-weight: normal;
 }
 
-.ih-footer__coc {
+.ih-footer__links {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.ih-footer__link {
   font-size: 0.8rem;
   color: var(--text-muted);
   text-decoration: none;
   font-weight: normal;
 }
 
-.ih-footer__coc:hover {
+.ih-footer__link:hover {
   color: var(--link-hover);
 }
 


### PR DESCRIPTION
## What

Adds **Terms of Service** (`/terms`) and **Privacy Policy** (`/privacy`) links to the site footer, next to the existing Code of Conduct link.

## Why

Both pages already exist as real, substantive content (`TermsView.vue`, `PrivacyView.vue`) and are prerendered, but they were only reachable by typing the URL directly — nothing in the footer or nav linked to them. This surfaces them so they're actually discoverable.

## Changes

- `BottomLinkTree.vue`: added the two `RouterLink`s, grouped all three footer links in a `<nav>` wrapper with a small gap, and generalized the link style class (`ih-footer__coc` → `ih-footer__link`).

No content changes to the Terms/Privacy pages themselves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)