### PR TITLE
Single local dev mode: real PocketBase + HMR, automatic DB bootstrap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,8 @@ IndyHackers Redux — a Vue 3 + PocketBase community site for Indianapolis tech.
 ## Commands
 
 ```bash
-npm run dev          # Vite dev server (localhost:5173); MSW mocks PocketBase by default
-npm run dev:backend  # Vite dev with VITE_USE_MSW=false — proxies to PocketBase on :8090
+npm run dev          # Vite dev server (localhost:5173); proxies /api + /_ to PocketBase on :8090
+npm run dev:mock     # Vite with VITE_USE_MSW=true — MSW fixtures; for reproducing e2e failures
 npm run build        # Production build
 npm run lint         # ESLint with auto-fix
 npm run format       # Prettier formatting
@@ -29,23 +29,30 @@ CI runs `vitest` and `playwright` jobs on pull requests. See [CONTRIBUTING.md](C
 Docker/Task commands for local PocketBase development:
 ```bash
 # Linux / amd64 (default TARGETARCH in docker-compose.yaml):
-npm run build && VERSION=dev docker-compose up --build
+docker-compose up -d      # required for `npm run dev` to have a backend
 
 # Apple Silicon only — Taskfile hardcodes TARGETARCH=arm64:
 task run-dev         # Run PocketBase + Vue with hot reload via docker-compose
 task build-dev       # Build dev Docker image
 ```
 
-See [README.md — Backend development (PocketBase)](README.md#backend-development-pocketbase) for bare-binary setup, admin login, and Option C (`dev:backend` / `VITE_USE_MSW=false`).
+See [README.md — Backend development (PocketBase)](README.md#backend-development-pocketbase) for bare-binary setup, admin login, and seeding a local database with `apply-mocks`.
 
 ## Architecture
 
-### Dual-Mode Development (MSW Mocking)
+### Local Development (single mode)
 
-The app runs in three local modes:
-- **Default dev (`npm run dev`)**: MSW intercepts PocketBase API calls. No backend needed.
-- **Backend dev (`npm run dev:backend` or `VITE_USE_MSW=false`)**: Vite proxies `/api` and `/_` to PocketBase on `:8090`. Requires PocketBase running (docker-compose or bare binary).
-- **Production**: Real PocketBase backend serves the built SPA.
+There is **one** way to develop: PocketBase on `:8090` (docker-compose) plus Vite on
+`:5173`. Vite proxies `/api` and `/_` to PocketBase, so the frontend has HMR and real
+data. `npm run dev` will not work without a running backend — that is intentional.
+
+MSW is a **test fixture, not a development mode**. It only activates when
+`VITE_USE_MSW=true`:
+- Vitest — via the Node interceptor in `vitest.setup.js` (`src/mocks/server.js`), independent of the browser worker
+- Playwright — its `webServer` runs `npm run dev:mock` on port **5174**, deliberately not 5173, so `reuseExistingServer` can't adopt a real-backend dev server and make the suite non-deterministic
+
+Do not reintroduce a mock-by-default dev path. If a task seems to need one, the answer is
+usually `apply-mocks` (seeds a real local database from the same `mocks.json`).
 
 Mock data lives in `src/mocks/mocks.json`. To update it: edit data in PocketBase admin UI → run `export-mocks` command in the container → copy `pb/hooks/mocks.json` to `src/mocks/mocks.json`.
 
@@ -75,8 +82,9 @@ Mock data lives in `src/mocks/mocks.json`. To update it: edit data in PocketBase
 
 ### Environment Variables
 
-- `VITE_USE_MSW` — set to `false` (or use `npm run dev:backend`) to proxy to real PocketBase on `:8090`
+- `VITE_USE_MSW` — `true` enables MSW. Set only by `npm run dev:mock` and Playwright; unset everywhere else.
 - Events come from the PocketBase `events` collection (synced from Google
   Calendar by `pb/hooks/calendar_sync.js`), not a browser-side Google API key.
-- Copy `.env.example` to `.env` for local development; the vars there are read
-  by the PocketBase container. Frontend MSW needs no secrets.
+- Copy `.env.example` to `.env`. PocketBase does **not** read `.env` itself —
+  `docker-compose.yaml` loads it via `env_file`, and hooks read values with
+  `$os.getenv`. Running the bare binary requires `set -a; source .env; set +a` first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ Docker/Task commands for local PocketBase development:
 ```bash
 # Linux / amd64 (default TARGETARCH in docker-compose.yaml):
 docker-compose up -d      # required for `npm run dev` to have a backend
+                          # migrates + seeds an empty pb/data automatically
 
 # Apple Silicon only — Taskfile hardcodes TARGETARCH=arm64:
 task run-dev         # Run PocketBase + Vue with hot reload via docker-compose
@@ -64,6 +65,7 @@ Mock data lives in `src/mocks/mocks.json`. To update it: edit data in PocketBase
 - `src/mocks/` — MSW handlers and shared mock data
 - `src/stores/` — Pinia stores
 - `pb/hooks/` — PocketBase server-side JS hooks (`.pb.js` files; `.pb.js.dev` suffix = dev-only, stripped in production)
+- `pb/entrypoint.sh` — container entrypoint: migrates, seeds fixtures when `NODE_ENV=development`, then serves. Seeding is gated so production never receives fixture users/jobs; `PB_SEED=off` / `PB_MIGRATE=off` opt out.
 - `pb/migrations/` — PocketBase schema migrations (auto-generated when editing schema in admin UI)
 
 ### Important Patterns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Thanks for helping improve the site. This is a living document—update it when 
 1. Clone the repo.
     - No push access? Fork it on GitHub, then clone your fork.
 2. Follow [README.md](README.md) for install, env setup, and local dev.
-3. **Backend work** (hooks, migrations, roles, admin): see [README — Backend development (PocketBase)](README.md#backend-development-pocketbase). Default `npm run dev` uses MSW mocks — no PocketBase container needed for frontend-only changes.
+3. **Local dev needs PocketBase running** — `npm run dev` proxies to it on `:8090` and will not work without it. Start it with `docker-compose up -d` and seed an empty database with `apply-mocks`: see [README — Backend development (PocketBase)](README.md#backend-development-pocketbase). This applies to frontend-only changes too.
 4. Branch from `dev` (ideally linked to a GitHub issue)
 5. Work locally until satisfied (don't forget tests!)
 6. Open a PR against `dev`
@@ -27,7 +27,7 @@ We use two complementary tools: **Vitest** for fast unit and component tests, **
 
 Commands: [README.md — Vitest](README.md#run-tests-with-vitest) and [Playwright](README.md#run-end-to-end-tests-with-playwright). CI on pull requests: [`.github/workflows/ci.yaml`](.github/workflows/ci.yaml) runs Vitest and Playwright (Chromium smoke tests).
 
-Vitest and Playwright currently use MSW — no Docker or PocketBase container is required to run tests locally or in CI. Containerized PocketBase integration tests are tracked in [#87](https://github.com/indyhackers/indyhackers-website/issues/87).
+Vitest and Playwright use MSW — no Docker or PocketBase container is required to run tests locally or in CI, even though normal development does need one. MSW is now scoped to tests only (`VITE_USE_MSW=true`); it does not intercept anything during `npm run dev`. Containerized PocketBase integration tests are tracked in [#87](https://github.com/indyhackers/indyhackers-website/issues/87).
 
 ### Vitest — default for most tests
 
@@ -43,8 +43,9 @@ Pure functions, single components, and anything you can mock with MSW or a Pocke
 - **Where:** `e2e/*.spec.js` (different tool, different suffix—[`vitest.config.js`](vitest.config.js) excludes `e2e/**`).
 - **Use for:** app shell loads, Vue Router resolves URLs, MSW service worker intercepts API calls in a real browser, critical public pages render.
 - **Do not use for:** logic already covered by Vitest, single-component CRUD, styling details, OAuth flows, or auth success/failure flows (until MSW auth handlers exist).
-- **Local:** `npm run test:e2e` — Playwright starts the Vite dev server automatically; MSW is active; no PocketBase container needed.
+- **Local:** `npm run test:e2e` — Playwright starts its own Vite server (`npm run dev:mock`) on port **5174** with MSW active; no PocketBase container needed. The separate port keeps it from reusing a real-backend dev server on 5173.
 - **CI:** `playwright` job on pull requests — Chromium only, same dev server + MSW setup as local.
+- **Reproducing a failure by hand:** `npm run dev:mock -- --port 5174`, then browse to `http://localhost:5174`.
 - **Debug:** `npm run test:e2e:ui` (interactive) or `npm run test:e2e:headed` (visible browser).
 
 The smoke suite ([`e2e/smoke.spec.js`](e2e/smoke.spec.js)) covers a curated set of public routes — that file is the source of truth. At the time of writing: home, login, signup, jobs, calendar, and slack. Keep e2e small; a flaky or duplicated e2e test is worse than none.

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,11 @@ EXPOSE 8090
 COPY --from=downloader /pocketbase /usr/local/bin/pocketbase
 COPY --from=vue-builder /app/ui/dist /pb_public
 
-ENTRYPOINT ["/usr/local/bin/pocketbase", "serve", "--http=0.0.0.0:8090", "--dir=/pb_data", "--publicDir=/pb_public", "--hooksDir=/pb_hooks"]
+# Applies migrations, seeds fixtures when NODE_ENV=development, then serves.
+# Note this passes --migrationsDir, which the previous bare `pocketbase serve`
+# ENTRYPOINT did not: without it PocketBase looks for migrations next to the
+# binary (/usr/local/bin/pb_migrations) and silently starts with no collections.
+COPY pb/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -38,28 +38,33 @@ Open `http://localhost:5173`. Vite proxies `/api` and `/_` through to PocketBase
 so the frontend runs against real data with hot reload, and the admin UI stays at
 `http://localhost:8090/_/`.
 
-A fresh `pb/data` starts completely empty — no schema, no content. Bootstrapping
-it takes two steps:
+**This is automatic.** `docker-compose up` on an empty `pb/data` applies every
+migration and seeds fixture data before the server starts, so a fresh clone gets
+a working database with no manual steps. [`pb/entrypoint.sh`](pb/entrypoint.sh)
+does the work; watch it happen with `docker-compose logs -f pocketbase`.
+
+What you get: `jobs`, `roles`, and `users` from `mocks.json`, plus anything the
+migrations seed themselves (topics, the `admin` role). Both phases are
+idempotent, so restarts don't duplicate anything.
+
+| Variable | Effect |
+| --- | --- |
+| `NODE_ENV=development` | Required for seeding. Set by `docker-compose.yaml`; the production compose file sets `production`, so **fixtures never reach production**. |
+| `PB_SEED=off` | Skip seeding but still migrate — use when you want a real empty database. |
+| `PB_MIGRATE=off` | Skip migrations entirely. |
+
+To re-seed by hand (after wiping `pb/data`, say):
 
 ```sh
-# 1. create the schema (30+ migrations)
-docker exec -it pocketbase /usr/local/bin/pocketbase \
-  migrate up --dir=/pb_data --migrationsDir=/pb_migrations
-
-# 2. seed jobs, roles, and users
-cp src/mocks/mocks.json pb/hooks/mocks.json      # see note below
 docker exec -it pocketbase /usr/local/bin/pocketbase \
   --hooksDir /pb_hooks --dir /pb_data apply-mocks
 ```
 
-**Step 1 is not automatic.** The image's `ENTRYPOINT` does not pass
-`--migrationsDir`, so `docker-compose up` on an empty `pb/data` starts a server
-with no collections at all — every `/api/collections/...` request returns 400.
-Existing checkouts don't hit this because their `pb/data` already has the schema.
-
-The `cp` in step 2 is likewise not optional on a fresh clone: `apply-mocks` reads
-`pb/hooks/mocks.json`, which is gitignored (`.gitignore:10`) as `export-mocks`
-output. The tracked copy is `src/mocks/mocks.json`.
+`apply-mocks` reads `pb/hooks/mocks.json`, which is gitignored (`.gitignore:10`)
+because it is `export-mocks` output; the tracked copy is `src/mocks/mocks.json`.
+The entrypoint copies the tracked version into place when the file is missing, so
+a fresh clone works — but if you run `apply-mocks` manually against a checkout
+that has never exported, `cp src/mocks/mocks.json pb/hooks/mocks.json` first.
 
 `apply-mocks` reads `pb/hooks/mocks.json` and inserts records that don't already
 exist, so it is safe to re-run. It seeds **`jobs`, `roles`, and `users` only** —

--- a/README.md
+++ b/README.md
@@ -86,12 +86,7 @@ still insert.
 
 ### Backend development (PocketBase)
 
-PocketBase has to be running for `npm run dev` to work at all. Use Option A
-unless you have a reason not to.
-
-#### Option A — docker-compose (recommended)
-
-Use this when you want parity with the project's Docker setup (dev hooks, volumes, same image as deploy). You may need to replace `docker-compose` with `docker compose`.
+PocketBase has to be running for `npm run dev` to work at all.
 
 ```sh
 docker-compose up --build                  # --build only needed the first time
@@ -111,28 +106,6 @@ and `/_/` routes.
 - Port `8090`; mounts `pb/hooks`, `pb/migrations`, and `pb/data` (data persists in `./pb/data`)
 - **Linux / amd64:** use the command above (`TARGETARCH` defaults to `amd64` in `docker-compose.yaml`)
 - **Apple Silicon:** `task run-dev` / `task build-dev` work but hardcode `TARGETARCH=arm64` in `Taskfile.yml` — on Linux, use the `docker-compose` command above instead
-
-#### Option B — bare PocketBase binary (alternative, no Docker, untested)
-
-Use this for the fastest native backend loop when you don't want Docker — hook edits, migrations, admin UI, `apply-mocks`. Prefer Option A when you need dev-only hooks (`.pb.js.dev` → `.pb.js`), which run through the dev Docker image.
-
-Download [PocketBase 0.39.4](https://github.com/pocketbase/pocketbase/releases/tag/v0.39.4) (matches `PB_VERSION` in the Dockerfile), then from the repo root:
-
-```sh
-set -a; source .env; set +a          # hooks read config via $os.getenv
-pocketbase serve \
-  --dir=pb/data \
-  --hooksDir=pb/hooks \
-  --migrationsDir=pb/migrations \
-  --publicDir=dist
-```
-
-PocketBase does not read `.env` itself — the `env_file` entry in
-`docker-compose.yaml` covers Option A, but running the binary directly means
-exporting the variables into your shell first, as above. Without them, hooks like
-`calendar_sync.js` throw `GOOGLE_API_KEY is not set`.
-
-Admin UI: `http://127.0.0.1:8090/_/`
 
 #### First-run admin login
 

--- a/README.md
+++ b/README.md
@@ -66,10 +66,6 @@ The entrypoint copies the tracked version into place when the file is missing, s
 a fresh clone works — but if you run `apply-mocks` manually against a checkout
 that has never exported, `cp src/mocks/mocks.json pb/hooks/mocks.json` first.
 
-`apply-mocks` reads `pb/hooks/mocks.json` and inserts records that don't already
-exist, so it is safe to re-run. It seeds **`jobs`, `roles`, and `users` only** —
-that is everything `mocks.json` contains.
-
 **Events are not seeded.** They come from the `events` collection, which
 `pb/hooks/calendar_sync.js` populates from Google Calendar, so an empty calendar
 means `GOOGLE_API_KEY` and `GOOGLE_CALENDAR_ID` are missing or the sync has not

--- a/README.md
+++ b/README.md
@@ -38,15 +38,41 @@ Open `http://localhost:5173`. Vite proxies `/api` and `/_` through to PocketBase
 so the frontend runs against real data with hot reload, and the admin UI stays at
 `http://localhost:8090/_/`.
 
-If your database is empty, seed it with the same fixture data the tests use:
+A fresh `pb/data` starts completely empty — no schema, no content. Bootstrapping
+it takes two steps:
 
 ```sh
+# 1. create the schema (30+ migrations)
+docker exec -it pocketbase /usr/local/bin/pocketbase \
+  migrate up --dir=/pb_data --migrationsDir=/pb_migrations
+
+# 2. seed jobs, roles, and users
+cp src/mocks/mocks.json pb/hooks/mocks.json      # see note below
 docker exec -it pocketbase /usr/local/bin/pocketbase \
   --hooksDir /pb_hooks --dir /pb_data apply-mocks
 ```
 
-`apply-mocks` reads `pb/hooks/mocks.json` and inserts any records that don't
-already exist, so it is safe to re-run.
+**Step 1 is not automatic.** The image's `ENTRYPOINT` does not pass
+`--migrationsDir`, so `docker-compose up` on an empty `pb/data` starts a server
+with no collections at all — every `/api/collections/...` request returns 400.
+Existing checkouts don't hit this because their `pb/data` already has the schema.
+
+The `cp` in step 2 is likewise not optional on a fresh clone: `apply-mocks` reads
+`pb/hooks/mocks.json`, which is gitignored (`.gitignore:10`) as `export-mocks`
+output. The tracked copy is `src/mocks/mocks.json`.
+
+`apply-mocks` reads `pb/hooks/mocks.json` and inserts records that don't already
+exist, so it is safe to re-run. It seeds **`jobs`, `roles`, and `users` only** —
+that is everything `mocks.json` contains.
+
+**Events are not seeded.** They come from the `events` collection, which
+`pb/hooks/calendar_sync.js` populates from Google Calendar, so an empty calendar
+means `GOOGLE_API_KEY` and `GOOGLE_CALENDAR_ID` are missing or the sync has not
+run yet. See [Environment Variables](#environment-variables).
+
+You will see `[jobs] new-job email failed` lines during seeding. That is the
+new-job notification hook finding no SMTP server configured locally; the records
+still insert.
 
 > **MSW is test-only.** [MSW](https://mswjs.io/) still backs Vitest and
 > Playwright, but it no longer intercepts anything during normal development.
@@ -125,6 +151,15 @@ Change that password immediately after first login. Assign roles via Collections
   Vitest and Playwright, and `pb/hooks/mocks.json` is what `apply-mocks` seeds a
   local database from. Keep them in sync so tests and local dev see the same data.
   For now, ignore `.dev` extension removals in git when committing hook changes.
+
+  > **`export-mocks` output needs hand-editing before it will re-import.** It
+  > serializes records with `publicExport()`, which omits fields the public API
+  > hides — notably `email` on the `users` auth collection, which is required on
+  > insert. A raw export therefore fails `apply-mocks` with
+  > `email: cannot be blank`. The snapshot also goes stale whenever a migration
+  > adds a required field, since the exported records predate it. After
+  > exporting, re-run `apply-mocks` against an empty database to confirm the
+  > snapshot still imports.
 
 ### Compile and Minify for Production
 

--- a/README.md
+++ b/README.md
@@ -18,32 +18,63 @@ npm install
 
 ### Environment Variables
 
-Copy `.env.example` to `.env`. The frontend needs no secrets for local
-development — API calls are intercepted by MSW mocks (see `src/mocks/`). Events
-are served by the PocketBase backend (synced from Google Calendar server-side),
-so there is no browser-side Google API key. The variables in `.env.example` are
-read by the PocketBase container in production; see the comments there.
+Copy `.env.example` to `.env`. The frontend itself needs no secrets, but the
+variables in `.env` are loaded into the PocketBase container (`env_file` in
+`docker-compose.yaml`) and read by the server-side hooks via `$os.getenv` —
+`GOOGLE_API_KEY` for calendar sync, the `SLACK_*` vars for invites, and so on. A
+hook that needs a missing variable fails at runtime, not at startup. Events are
+synced from Google Calendar server-side, so there is no browser-side Google key.
 
 ### Compile and Hot-Reload for Development
 
+There is one way to run the app locally: PocketBase on `:8090`, Vite on `:5173`.
+
 ```sh
-npm run dev
+docker-compose up -d          # PocketBase on :8090 (see Backend development below)
+npm run dev                   # Vite + HMR on :5173
 ```
 
-By default, `npm run dev` uses [MSW](https://mswjs.io/) to mock PocketBase API calls — no backend container required. See [Backend development (PocketBase)](#backend-development-pocketbase) when you need a real PocketBase instance (hooks, migrations, roles, Slack, admin screens).
+Open `http://localhost:5173`. Vite proxies `/api` and `/_` through to PocketBase,
+so the frontend runs against real data with hot reload, and the admin UI stays at
+`http://localhost:8090/_/`.
+
+If your database is empty, seed it with the same fixture data the tests use:
+
+```sh
+docker exec -it pocketbase /usr/local/bin/pocketbase \
+  --hooksDir /pb_hooks --dir /pb_data apply-mocks
+```
+
+`apply-mocks` reads `pb/hooks/mocks.json` and inserts any records that don't
+already exist, so it is safe to re-run.
+
+> **MSW is test-only.** [MSW](https://mswjs.io/) still backs Vitest and
+> Playwright, but it no longer intercepts anything during normal development.
+> `npm run dev:mock` starts Vite with `VITE_USE_MSW=true` if you need to
+> reproduce an e2e failure by hand; it is not a development mode.
 
 ### Backend development (PocketBase)
 
-Use real PocketBase when working on server-side hooks, schema migrations, collection rules, Slack invites, roles, or the admin UI. The Vite dev server with MSW never talks to PocketBase — it intercepts all `/api` calls with mocks.
+PocketBase has to be running for `npm run dev` to work at all. Use Option A
+unless you have a reason not to.
 
 #### Option A — docker-compose (recommended)
 
 Use this when you want parity with the project's Docker setup (dev hooks, volumes, same image as deploy). You may need to replace `docker-compose` with `docker compose`.
 
 ```sh
-npm run build                              # populates ./dist → PocketBase public dir
-VERSION=dev docker-compose up --build
+docker-compose up --build                  # --build only needed the first time
 ```
+
+The image tag defaults to `dev` via `${VERSION:-dev}`; set `VERSION=` explicitly
+only when building a tagged image to push. `--build` is needed after Dockerfile
+or `PB_VERSION` changes — hooks, migrations, and `dist` are bind-mounted, so
+edits to those take effect without rebuilding.
+
+`./dist` is mounted as PocketBase's public dir, but you only need to
+`npm run build` into it if you want PocketBase itself to serve the site at
+`:8090`. For day-to-day work you use Vite on `:5173` and only PocketBase's `/api`
+and `/_/` routes.
 
 - Admin UI: `http://localhost:8090/_/` (**trailing slash required** — `/_` without it will not work)
 - Port `8090`; mounts `pb/hooks`, `pb/migrations`, and `pb/data` (data persists in `./pb/data`)
@@ -54,9 +85,10 @@ VERSION=dev docker-compose up --build
 
 Use this for the fastest native backend loop when you don't want Docker — hook edits, migrations, admin UI, `apply-mocks`. Prefer Option A when you need dev-only hooks (`.pb.js.dev` → `.pb.js`), which run through the dev Docker image.
 
-Download [PocketBase 0.39.4](https://github.com/pocketbase/pocketbase/releases/tag/v0.39.4) (matches `PB_VERSION` in the Dockerfile), then from the repo root (after `npm run build`):
+Download [PocketBase 0.39.4](https://github.com/pocketbase/pocketbase/releases/tag/v0.39.4) (matches `PB_VERSION` in the Dockerfile), then from the repo root:
 
 ```sh
+set -a; source .env; set +a          # hooks read config via $os.getenv
 pocketbase serve \
   --dir=pb/data \
   --hooksDir=pb/hooks \
@@ -64,16 +96,12 @@ pocketbase serve \
   --publicDir=dist
 ```
 
+PocketBase does not read `.env` itself — the `env_file` entry in
+`docker-compose.yaml` covers Option A, but running the binary directly means
+exporting the variables into your shell first, as above. Without them, hooks like
+`calendar_sync.js` throw `GOOGLE_API_KEY is not set`.
+
 Admin UI: `http://127.0.0.1:8090/_/`
-
-#### Option C — Vite hot reload against real PocketBase
-
-For full-stack work with hot-reloading frontend pointed at real data:
-
-1. Start PocketBase (Option A or B above)
-2. Set `VITE_USE_MSW=false` in `.env` (or run `npm run dev:backend`)
-3. Open `http://localhost:5173` — API calls proxy to PocketBase on `:8090`
-4. PocketBase admin UI remains at `http://localhost:8090/_/` (not on the Vite port)
 
 #### First-run admin login
 
@@ -93,7 +121,10 @@ Change that password immediately after first login. Assign roles via Collections
   docker exec -it pocketbase /usr/local/bin/pocketbase --hooksDir /pb_hooks --dir /pb_data export-mocks
   cp pb/hooks/mocks.json src/mocks/mocks.json   # commit both to keep MSW in sync
   ```
-  Import with the `apply-mocks` subcommand inside the container. For now, ignore `.dev` extension removals in git when committing hook changes.
+  `mocks.json` serves two purposes: `src/mocks/mocks.json` is the fixture set for
+  Vitest and Playwright, and `pb/hooks/mocks.json` is what `apply-mocks` seeds a
+  local database from. Keep them in sync so tests and local dev see the same data.
+  For now, ignore `.dev` extension removals in git when committing hook changes.
 
 ### Compile and Minify for Production
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   indyhackers-redux:
-    image: indyhackers-${TARGETARCH:-amd64}:${VERSION}
+    image: indyhackers-${TARGETARCH:-amd64}:${VERSION:-dev}
     build:
       context: .
       args:
@@ -9,6 +9,11 @@ services:
         PB_VERSION: 0.39.4
         PB_ENV: development
     container_name: pocketbase
+    # Hooks read config via $os.getenv (GOOGLE_API_KEY, SLACK_*, SITE_URL, ...).
+    # Compose only uses .env for ${VAR} interpolation in this file, so the values
+    # have to be passed into the container explicitly.
+    env_file:
+      - .env
     environment:
       NODE_ENV: development
     restart: unless-stopped

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "dev:backend": "VITE_USE_MSW=false vite",
+    "dev:mock": "VITE_USE_MSW=true vite",
     "build": "vite-ssg build && node scripts/generate-sitemap.mjs",
     "build:spa": "vite build",
     "preview": "vite preview",

--- a/pb/entrypoint.sh
+++ b/pb/entrypoint.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# Container entrypoint: bring the database up to date, optionally seed it, then
+# serve. Replaces the bare `pocketbase serve` ENTRYPOINT so that a fresh
+# `pb/data` becomes a usable database without any manual steps.
+set -e
+
+PB=/usr/local/bin/pocketbase
+DATA_DIR=/pb_data
+HOOKS_DIR=/pb_hooks
+MIGRATIONS_DIR=/pb_migrations
+
+log() { echo "[entrypoint] $*"; }
+
+# --- schema -----------------------------------------------------------------
+# `serve --migrationsDir` would automigrate on its own, but seeding has to
+# happen before the server starts accepting requests, and apply-mocks needs the
+# collections to already exist. So apply migrations explicitly and in order.
+# Already-applied migrations are skipped, so this is safe on every boot.
+if [ "$PB_MIGRATE" = "off" ]; then
+  log "PB_MIGRATE=off — skipping migrations"
+else
+  log "applying migrations"
+  "$PB" migrate up --dir="$DATA_DIR" --migrationsDir="$MIGRATIONS_DIR"
+fi
+
+# --- seed data --------------------------------------------------------------
+# Fixtures only. These include fake users and a deliberately unapproved "Bunk
+# Job Title" record, so this must never run against production data.
+if [ "$NODE_ENV" = "development" ] && [ "$PB_SEED" != "off" ]; then
+  # apply-mocks reads $__hooks/mocks.json. That path is gitignored (it is
+  # export-mocks output); the tracked copy is src/mocks/mocks.json, baked into
+  # the image at /mocks.json. Only copy when absent so a local export made via
+  # export-mocks is never clobbered.
+  if [ ! -f "$HOOKS_DIR/mocks.json" ] && [ -f /mocks.json ]; then
+    log "no $HOOKS_DIR/mocks.json — seeding from the copy baked into the image"
+    cp /mocks.json "$HOOKS_DIR/mocks.json"
+  fi
+
+  if [ -f "$HOOKS_DIR/mocks.json" ]; then
+    log "seeding fixtures (idempotent; existing records are skipped)"
+    # Non-fatal: a stale snapshot missing a newly-required field should not
+    # stop the server from coming up.
+    "$PB" --hooksDir "$HOOKS_DIR" --dir "$DATA_DIR" apply-mocks \
+      || log "seeding failed — continuing without fixtures"
+  else
+    log "no mocks.json found — skipping seed"
+  fi
+elif [ "$PB_SEED" = "off" ]; then
+  log "PB_SEED=off — skipping seed"
+fi
+
+# --- serve ------------------------------------------------------------------
+log "starting pocketbase"
+exec "$PB" serve \
+  --http=0.0.0.0:8090 \
+  --dir="$DATA_DIR" \
+  --publicDir=/pb_public \
+  --hooksDir="$HOOKS_DIR" \
+  --migrationsDir="$MIGRATIONS_DIR"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -33,8 +33,9 @@ export default defineConfig({
   use: {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:5173',
+    /* Base URL to use in actions like `await page.goto('/')`. Port 5174, not the
+       5173 dev server — see the webServer block below. */
+    baseURL: 'http://localhost:5174',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -60,12 +61,16 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     /**
-     * Always use the Vite dev server so MSW is active (see src/main.js).
-     * Smoke tests assert against mock data, not a production PocketBase build.
-     * Playwright re-uses an existing dev server locally when one is already running.
+     * e2e runs against MSW, not a real backend, so specs stay deterministic and
+     * need no PocketBase container. `npm run dev:mock` sets VITE_USE_MSW=true —
+     * plain `npm run dev` talks to real PocketBase and would make these flaky.
+     *
+     * Deliberately port 5174: that keeps this mock server from colliding with a
+     * dev server on 5173, and stops reuseExistingServer from silently adopting
+     * one (which would run the suite against real data).
      */
-    command: 'vite dev --port 5173',
-    port: 5173,
+    command: 'npm run dev:mock -- --port 5174',
+    port: 5174,
     reuseExistingServer: !process.env.CI
   }
 })

--- a/src/main.js
+++ b/src/main.js
@@ -103,10 +103,12 @@ export const createApp = ViteSSG(
       import('@popperjs/core/dist/umd/popper.min.js')
       import('bootstrap/dist/js/bootstrap.min.js')
 
-      // Dev-only: start the MSW mock backend and wait for it before mounting
-      // (vite-ssg awaits this callback), so initial fetches are intercepted.
-      // Set VITE_USE_MSW=false to proxy API calls to real PocketBase on :8090.
-      if (import.meta.env.DEV && import.meta.env.VITE_USE_MSW !== 'false') {
+      // Opt-in only: `npm run dev` talks to the real PocketBase on :8090 via the
+      // Vite proxy (see vite.config.js). MSW is a test fixture — Playwright sets
+      // VITE_USE_MSW=true so e2e specs run against deterministic mock data.
+      // We await the worker before mounting (vite-ssg awaits this callback) so
+      // initial fetches are intercepted.
+      if (import.meta.env.DEV && import.meta.env.VITE_USE_MSW === 'true') {
         const { worker } = await import('./mocks/browser')
         await worker.start()
       }

--- a/src/mocks/mocks.json
+++ b/src/mocks/mocks.json
@@ -101,6 +101,42 @@
           "presentable": false,
           "unique": false,
           "options": {}
+        },
+        {
+          "autogeneratePattern": "",
+          "hidden": false,
+          "id": "text1579384326",
+          "max": 0,
+          "min": 0,
+          "name": "name",
+          "pattern": "",
+          "presentable": false,
+          "primaryKey": false,
+          "required": true,
+          "system": false,
+          "type": "text"
+        },
+        {
+          "exceptDomains": [],
+          "hidden": false,
+          "id": "email3885137012",
+          "name": "email",
+          "onlyDomains": [],
+          "presentable": false,
+          "required": true,
+          "system": false,
+          "type": "email"
+        },
+        {
+          "convertURLs": false,
+          "hidden": false,
+          "id": "editor4243115111",
+          "maxSize": 0,
+          "name": "how_to_apply",
+          "presentable": false,
+          "required": true,
+          "system": false,
+          "type": "editor"
         }
       ],
       "indexes": [],
@@ -119,13 +155,16 @@
         "collectionName": "jobs",
         "company": " Knowledge Services",
         "created": "2024-09-18 15:56:45.162Z",
-        "description": "\u003Cp\u003EKnowledge Services is actively seeking a Data Product Owner for a contract-to-hire client opening in Indianapolis, IN. Applicants must be able to work in a hybrid work schedule of 2-days onsite (Tues and Wed) each week in downtown Indianapolis. Parking is provided!\u003C/p\u003E\r\n\u003Cp\u003EData Product Owner Responsibilities: Product Vision and Strategy: &bull; Develop and communicate a clear vision and strategy for data products, aligning with business goals and objectives.\u003C/p\u003E\r\n\u003Cp\u003EProduct Roadmap and Planning: &bull; Create and maintain a detailed product roadmap, outlining the development journey and key milestones. &bull; Define key performance indicators (KPIs) to measure the success of data products.\u003C/p\u003E\r\n\u003Cp\u003EStakeholder Management: &bull; Act as a bridge between data teams, stakeholders, and end-users, translating complex data concepts into actionable insights. &bull; Collaborate with cross-functional teams to gather feedback and ensure data products meet stakeholder requirements.\u003C/p\u003E\r\n\u003Cp\u003EBacklog Management: &bull; Create, maintain, and prioritize the product backlog, ensuring that the most valuable features are delivered first.\u003C/p\u003E\r\n\u003Cp\u003ECross-Functional Collaboration: &bull; Work closely with data engineers, data analysts, and other cross-functional teams to ensure successful product development and delivery.\u003C/p\u003E\r\n\u003Cp\u003EProject Planning: &bull; Oversee project planning, resource allocation, and timeline management to ensure timely delivery of high-quality data products.\u003C/p\u003E\r\n\u003Cp\u003EQuality Assurance: &bull; Ensure that data products meet quality standards and are delivered within budget.\u003C/p\u003E\r\n\u003Cp\u003EMarket Analysis: &bull; Conduct market research and competitive analysis to identify opportunities for innovation and improvement.\u003C/p\u003E\r\n\u003Cp\u003EUser Feedback: &bull; Gather and analyze user feedback to continuously improve data products and enhance user experience. Focus on the user experience, ensuring data products are intuitive and meet user needs\u003C/p\u003E\r\n\u003Cp\u003EData Governance: &bull; Ensure that data used within the data products is clean, secure, and adheres to company-wide governance policies Ensure data products comply with accepted standards and data governance rules. Provide detailed metadata descriptions and ensure data quality and integrity.\u003C/p\u003E\r\n\u003Cp\u003EData Literacy and Training: &bull; Promote data literacy within the organization, providing training and support to stakeholders. &bull; Foster a culture of data-driven decision-making\u003C/p\u003E\r\n\u003Cp\u003EData Product Owner Requirements: &bull; Bachelor&rsquo;s degree in computer science, Data Science, Business Administration, or a related field. Master&rsquo;s degree preferred. &bull; Minimum of 5 years of experience as a Product Manager/Product Owner, product management, with a focus on data products or data-driven projects. &bull; Strong understanding of the modern data stack, data science, data engineering, and analytics. Proficiency in SQL, Python, or other relevant programming languages. &bull; Ability to translate complex data concepts into actionable business insights. &bull; Excellent verbal and written communication skills, with the ability to effectively communicate with technical and non-technical stakeholders. &bull; Proven ability to lead cross-functional teams and manage multiple projects simultaneously. &bull; Strong analytical and problem-solving skills, with a focus on delivering innovative solutions\u003C/p\u003E\r\n\u003Cp\u003ETo apply, please contact&nbsp;\u003Ca href=\"mailto:pauld@knowledgeservices.com\"\u003EPaul Doray\u003C/a\u003E\u003C/p\u003E",
+        "description": "<p>Knowledge Services is actively seeking a Data Product Owner for a contract-to-hire client opening in Indianapolis, IN. Applicants must be able to work in a hybrid work schedule of 2-days onsite (Tues and Wed) each week in downtown Indianapolis. Parking is provided!</p>\r\n<p>Data Product Owner Responsibilities: Product Vision and Strategy: &bull; Develop and communicate a clear vision and strategy for data products, aligning with business goals and objectives.</p>\r\n<p>Product Roadmap and Planning: &bull; Create and maintain a detailed product roadmap, outlining the development journey and key milestones. &bull; Define key performance indicators (KPIs) to measure the success of data products.</p>\r\n<p>Stakeholder Management: &bull; Act as a bridge between data teams, stakeholders, and end-users, translating complex data concepts into actionable insights. &bull; Collaborate with cross-functional teams to gather feedback and ensure data products meet stakeholder requirements.</p>\r\n<p>Backlog Management: &bull; Create, maintain, and prioritize the product backlog, ensuring that the most valuable features are delivered first.</p>\r\n<p>Cross-Functional Collaboration: &bull; Work closely with data engineers, data analysts, and other cross-functional teams to ensure successful product development and delivery.</p>\r\n<p>Project Planning: &bull; Oversee project planning, resource allocation, and timeline management to ensure timely delivery of high-quality data products.</p>\r\n<p>Quality Assurance: &bull; Ensure that data products meet quality standards and are delivered within budget.</p>\r\n<p>Market Analysis: &bull; Conduct market research and competitive analysis to identify opportunities for innovation and improvement.</p>\r\n<p>User Feedback: &bull; Gather and analyze user feedback to continuously improve data products and enhance user experience. Focus on the user experience, ensuring data products are intuitive and meet user needs</p>\r\n<p>Data Governance: &bull; Ensure that data used within the data products is clean, secure, and adheres to company-wide governance policies Ensure data products comply with accepted standards and data governance rules. Provide detailed metadata descriptions and ensure data quality and integrity.</p>\r\n<p>Data Literacy and Training: &bull; Promote data literacy within the organization, providing training and support to stakeholders. &bull; Foster a culture of data-driven decision-making</p>\r\n<p>Data Product Owner Requirements: &bull; Bachelor&rsquo;s degree in computer science, Data Science, Business Administration, or a related field. Master&rsquo;s degree preferred. &bull; Minimum of 5 years of experience as a Product Manager/Product Owner, product management, with a focus on data products or data-driven projects. &bull; Strong understanding of the modern data stack, data science, data engineering, and analytics. Proficiency in SQL, Python, or other relevant programming languages. &bull; Ability to translate complex data concepts into actionable business insights. &bull; Excellent verbal and written communication skills, with the ability to effectively communicate with technical and non-technical stakeholders. &bull; Proven ability to lead cross-functional teams and manage multiple projects simultaneously. &bull; Strong analytical and problem-solving skills, with a focus on delivering innovative solutions</p>\r\n<p>To apply, please contact&nbsp;<a href=\"mailto:pauld@knowledgeservices.com\">Paul Doray</a></p>",
         "id": "9jguvjqw6fzjb79",
         "salary_max": 125,
         "salary_min": 110,
         "title": "Data Product Owner",
         "updated": "2024-09-18 15:56:45.162Z",
-        "user": "p7ysp1yvccn2195"
+        "user": "p7ysp1yvccn2195",
+        "name": "Hiring Team",
+        "email": "hiring@example.com",
+        "how_to_apply": "<p>Email <a href=\"mailto:hiring@example.com\">hiring@example.com</a> with a resume.</p>"
       },
       {
         "approved": true,
@@ -134,13 +173,16 @@
         "collectionName": "jobs",
         "company": "Theoris",
         "created": "2024-09-18 16:16:05.309Z",
-        "description": "\u003Cp\u003EWe have 3 fully remote .NET positions available for long-term, benefited contract to hire. Ideally looking for React experience on the front end.\u003C/p\u003E\r\n\u003Cp\u003EASP.Net, MVC, .NET 4.8, .NET 8 50% is frontend 50% API development\u003C/p\u003E\r\n\u003Cp\u003EPlease reach out if you may want more details.\u003C/p\u003E\r\n\u003Cp\u003E\"To apply, please contact&nbsp;\u003Ca href=\"mailto:mdodson@theoris.com\"\u003EMegan Dodson\u003C/a\u003E\u003C/p\u003E",
+        "description": "<p>We have 3 fully remote .NET positions available for long-term, benefited contract to hire. Ideally looking for React experience on the front end.</p>\r\n<p>ASP.Net, MVC, .NET 4.8, .NET 8 50% is frontend 50% API development</p>\r\n<p>Please reach out if you may want more details.</p>\r\n<p>\"To apply, please contact&nbsp;<a href=\"mailto:mdodson@theoris.com\">Megan Dodson</a></p>",
         "id": "vx9r0y79gj419dt",
         "salary_max": 125,
         "salary_min": 115,
         "title": "Senior .NET Developer",
         "updated": "2024-09-18 16:17:07.547Z",
-        "user": "78e6lprv2po3upi"
+        "user": "78e6lprv2po3upi",
+        "name": "Hiring Team",
+        "email": "hiring@example.com",
+        "how_to_apply": "<p>Email <a href=\"mailto:hiring@example.com\">hiring@example.com</a> with a resume.</p>"
       },
       {
         "approved": true,
@@ -149,13 +191,16 @@
         "collectionName": "jobs",
         "company": "SEP",
         "created": "2024-09-18 16:16:59.040Z",
-        "description": "\u003Cp\u003EFor more details about the role and to apply for the role, please visit:&nbsp;\u003Ca href=\"https://jobs.lever.co/sep/0eccbd97-a731-4912-8856-a92942897be9\"\u003Ehttps://jobs.lever.co/sep/0eccbd97-a731-4912-8856-a92942897be9\u003C/a\u003E\u003C/p\u003E",
+        "description": "<p>For more details about the role and to apply for the role, please visit:&nbsp;<a href=\"https://jobs.lever.co/sep/0eccbd97-a731-4912-8856-a92942897be9\">https://jobs.lever.co/sep/0eccbd97-a731-4912-8856-a92942897be9</a></p>",
         "id": "yyfjkp1cxfnbvpy",
         "salary_max": 105,
         "salary_min": 100,
         "title": "Senior/Lead Product Designer",
         "updated": "2024-09-18 16:17:11.089Z",
-        "user": "p7ysp1yvccn2195"
+        "user": "p7ysp1yvccn2195",
+        "name": "Hiring Team",
+        "email": "hiring@example.com",
+        "how_to_apply": "<p>Email <a href=\"mailto:hiring@example.com\">hiring@example.com</a> with a resume.</p>"
       },
       {
         "approved": false,
@@ -164,13 +209,16 @@
         "collectionName": "jobs",
         "company": "Bunk Company",
         "created": "2024-09-18 16:26:50.409Z",
-        "description": "\u003Cp\u003EYou can make thousands of dollars a month by starting your own fans page, or joining a pyramid scheme... have you heard about Amway? Let me tell you about it. \u003Ca href=\"mailto:john.nefarious@somewhere.else\" target=\"_blank\" rel=\"noopener\"\u003Ejohn.nefarious@somewhere.else\u003C/a\u003E\u003C/p\u003E",
+        "description": "<p>You can make thousands of dollars a month by starting your own fans page, or joining a pyramid scheme... have you heard about Amway? Let me tell you about it. <a href=\"mailto:john.nefarious@somewhere.else\" target=\"_blank\" rel=\"noopener\">john.nefarious@somewhere.else</a></p>",
         "id": "uuzcym8emnjupr1",
         "salary_max": 450,
         "salary_min": 300,
         "title": "Bunk Job Title",
         "updated": "2024-09-18 16:26:50.409Z",
-        "user": "ufvy8er5x1z8uy8"
+        "user": "ufvy8er5x1z8uy8",
+        "name": "Hiring Team",
+        "email": "hiring@example.com",
+        "how_to_apply": "<p>Email <a href=\"mailto:hiring@example.com\">hiring@example.com</a> with a resume.</p>"
       }
     ]
   },
@@ -208,6 +256,18 @@
           "options": {
             "convertUrls": false
           }
+        },
+        {
+          "hidden": false,
+          "id": "number2683508278",
+          "max": 100,
+          "min": 0,
+          "name": "level",
+          "onlyInt": true,
+          "presentable": false,
+          "required": true,
+          "system": false,
+          "type": "number"
         }
       ],
       "indexes": [],
@@ -223,28 +283,21 @@
         "collectionId": "8w3c1s8vh09ggi7",
         "collectionName": "roles",
         "created": "2024-09-18 15:43:56.427Z",
-        "description": "\u003Cp\u003ERole for Employers (grants access to create/modify job postings)\u003C/p\u003E",
+        "description": "<p>Role for Employers (grants access to create/modify job postings)</p>",
         "id": "c4zs8dywx1b4oum",
         "name": "employer",
-        "updated": "2024-09-18 15:43:56.427Z"
-      },
-      {
-        "collectionId": "8w3c1s8vh09ggi7",
-        "collectionName": "roles",
-        "created": "2024-09-18 15:45:05.731Z",
-        "description": "\u003Cp\u003ERole for Website Admins (grants access to Admin UI)\u003C/p\u003E",
-        "id": "dvd8qcpwdva72z0",
-        "name": "admin",
-        "updated": "2024-09-18 15:45:05.731Z"
+        "updated": "2024-09-18 15:43:56.427Z",
+        "level": 50
       },
       {
         "collectionId": "8w3c1s8vh09ggi7",
         "collectionName": "roles",
         "created": "2024-09-18 15:52:30.362Z",
-        "description": "\u003Cp\u003ERole for IndyHackers members (joined via Slack)\u003C/p\u003E",
+        "description": "<p>Role for IndyHackers members (joined via Slack)</p>",
         "id": "po8xycl3w2b6h0o",
         "name": "member",
-        "updated": "2024-09-18 15:52:30.362Z"
+        "updated": "2024-09-18 15:52:30.362Z",
+        "level": 10
       }
     ]
   },
@@ -280,7 +333,13 @@
           "presentable": false,
           "unique": false,
           "options": {
-            "mimeTypes": ["image/jpeg", "image/png", "image/svg+xml", "image/gif", "image/webp"],
+            "mimeTypes": [
+              "image/jpeg",
+              "image/png",
+              "image/svg+xml",
+              "image/gif",
+              "image/webp"
+            ],
             "thumbs": null,
             "maxSelect": 1,
             "maxSize": 5242880,
@@ -331,10 +390,13 @@
         "emailVisibility": false,
         "id": "0yi0op6wkn5olcd",
         "name": "Joe Public",
-        "roles": ["po8xycl3w2b6h0o"],
+        "roles": [
+          "po8xycl3w2b6h0o"
+        ],
         "updated": "2024-09-18 15:52:48.852Z",
         "username": "joe_public",
-        "verified": true
+        "verified": true,
+        "email": "joe.public@example.com"
       },
       {
         "avatar": "",
@@ -344,10 +406,14 @@
         "emailVisibility": false,
         "id": "78e6lprv2po3upi",
         "name": "Jack Employer",
-        "roles": ["c4zs8dywx1b4oum", "po8xycl3w2b6h0o"],
+        "roles": [
+          "c4zs8dywx1b4oum",
+          "po8xycl3w2b6h0o"
+        ],
         "updated": "2024-09-18 15:53:02.056Z",
         "username": "jack_employer",
-        "verified": true
+        "verified": true,
+        "email": "jack.employer@example.com"
       },
       {
         "avatar": "",
@@ -357,10 +423,13 @@
         "emailVisibility": false,
         "id": "p7ysp1yvccn2195",
         "name": "Sally Employer",
-        "roles": ["c4zs8dywx1b4oum"],
+        "roles": [
+          "c4zs8dywx1b4oum"
+        ],
         "updated": "2024-09-18 15:46:02.794Z",
         "username": "sally_employer",
-        "verified": true
+        "verified": true,
+        "email": "sally.employer@example.com"
       },
       {
         "avatar": "",
@@ -370,10 +439,13 @@
         "emailVisibility": false,
         "id": "ufvy8er5x1z8uy8",
         "name": "John Nefarious",
-        "roles": ["c4zs8dywx1b4oum"],
+        "roles": [
+          "c4zs8dywx1b4oum"
+        ],
         "updated": "2024-09-18 16:24:32.490Z",
         "username": "john_nefarious",
-        "verified": false
+        "verified": false,
+        "email": "john.nefarious@example.com"
       }
     ]
   }

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,7 +17,9 @@ export default defineConfig({
     strictPort: true,
     // Allow access via the temporary Cloudflare quick tunnel
     allowedHosts: ['.trycloudflare.com'],
-    // When VITE_USE_MSW=false, API and admin routes proxy to local PocketBase
+    // API and admin routes proxy to the local PocketBase container. This is the
+    // default dev path; it is inert under VITE_USE_MSW=true, where the service
+    // worker intercepts /api before a request ever reaches the proxy.
     proxy: {
       '/api': { target: 'http://localhost:8090', changeOrigin: true },
       '/_': { target: 'http://localhost:8090', changeOrigin: true }


### PR DESCRIPTION
## What

Collapses local development down to one path — Vite on `:5173` with HMR, proxying to a real PocketBase on `:8090` — and makes `docker-compose up` produce a working database from an empty `pb/data` with no manual steps.

Previously `npm run dev` served MSW mocks by default, so frontend work never exercised the real backend, and a fresh clone needed undocumented manual migration + seeding.

## Changes

**MSW becomes a test fixture, not a dev mode**
- `src/main.js` — worker starts on `VITE_USE_MSW === 'true'` (opt-in); previously started unless `=== 'false'`
- `package.json` — `dev:backend` → `dev:mock`, which is what Playwright runs and what you use to reproduce an e2e failure by hand
- `playwright.config.js` — mock server moves to port **5174**. On 5173, `reuseExistingServer` would silently adopt a real-backend dev server and run the suite against live data
- Vitest is unaffected: `vitest.setup.js` uses the Node interceptor, which is independent of the browser worker

**Automatic database bootstrap**
- New `pb/entrypoint.sh` replaces the bare `pocketbase serve` ENTRYPOINT: migrate → seed → serve, both phases idempotent
- Root cause of the old breakage: the ENTRYPOINT never passed `--migrationsDir`, so PocketBase looked next to the binary (`/usr/local/bin/pb_migrations`) and started with **zero collections** — every `/api/collections/...` returned 400
- Seeding is gated on `NODE_ENV=development`; `PB_SEED=off` / `PB_MIGRATE=off` opt out

**`apply-mocks` fixed against the current schema** — `mocks.json` snapshotted a schema several migrations stale:

| Collection | Missing field | Added by |
| --- | --- | --- |
| `jobs` | `name`, `email`, `how_to_apply` | migration 017 |
| `roles` | `level` (0–100) | migration 002 |
| `users` | `email` | auth requirement |

Also drops `admin` from the snapshot — migration 025 already seeds it and `applyMocks` matches by id, so importing produced a second admin role. No fixture user referenced it.

**Config fixes found along the way**
- `docker-compose.yaml` — `env_file: [.env]`. Compose only used `.env` for `${VAR}` interpolation, so hooks never received `GOOGLE_API_KEY` and `calendar_sync.js` threw `GOOGLE_API_KEY is not set` despite the value being present
- `docker-compose.yaml` — `${VERSION:-dev}` so `docker-compose up` works without a `VERSION=` prefix

## Reviewer note — this changes production behavior

Migrations now auto-apply wherever the image runs, **including production**, which the old ENTRYPOINT never did. This is PocketBase's own default (`--automigrate` is `true`) and it's required for the feature to work, but it is a real deploy-behavior change and worth a deliberate yes/no.

To keep the old behavior, add `PB_MIGRATE: off` to the environment block in `docker-compose_production.yaml` — no rebuild needed.

Seeding cannot reach production: the production compose file sets `NODE_ENV=production`, verified below.

## Verification

- **Vitest** 42/42, **Playwright** 6/6 on 5174 (including "jobs page loads with mock data", confirming MSW is genuinely active there)
- Production build succeeds
- `/api/health` and `/api/collections/events/records` proxy 5173 → 8090
- Bootstrap tested on throwaway data dirs, four paths:
  - empty + `development`: 30 migrations, 10 records, 3 public jobs / 3 roles / 19 topics
  - restart: no re-application, no duplicate inserts
  - empty + `production`: migrations applied, **seeding skipped, 0 jobs**
  - hooks dir with no `mocks.json`: falls back to the image copy and seeds

## Follow-ups not included

- `export-mocks` serializes via `publicExport()`, which strips `email` on auth collections — so the next raw export reintroduces the bug fixed here. Documented in the README; the real fix is in `pb/hooks/mocks.js`
- Events are still not seeded by `apply-mocks`; they come from `calendar_sync.js` via Google Calendar
- README previously claimed a `.pb.js.dev` → `.pb.js` renaming hook exists. No such mechanism is in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)