### PR TITLE
Fix founding year: 2017 → 2008

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -63,7 +63,7 @@ export const routes = [
       meta: {
         title: 'About',
         description:
-          "Learn about IndyHackers — Indiana's tech community since 2017: our meetups, our mission, and how to get involved."
+          "Learn about IndyHackers — Indiana's tech community since 2008: our meetups, our mission, and how to get involved."
       }
     },
     {

--- a/src/views/AboutView.vue
+++ b/src/views/AboutView.vue
@@ -6,7 +6,7 @@
       <div class="about-hero__columns">
         <div class="about-hero__story">
           <p>
-            In 2017, a few Ruby developers in Indianapolis started meeting for coffee.
+            In 2008, a few Ruby developers in Indianapolis started meeting for coffee.
             No agenda, no sponsors, just people who liked building things and wanted to
             know who else was doing the same.
           </p>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -3,7 +3,7 @@
   <section class="hero">
     <div class="ih-container hero__layout">
       <div class="hero__copy">
-        <h1 class="hero__heading">Indiana's tech community<br />since 2017</h1>
+        <h1 class="hero__heading">Indiana's tech community<br />since 2008</h1>
         <p class="hero__sub">
           What started as a few devs meeting for coffee is now 3,000 members strong.
           Come hang out.


### PR DESCRIPTION
## Summary
The site stated the org has been around **since 2017** in three places; the correct founding year is **2008**. This corrects all three.

## Changes
- `src/views/HomeView.vue` — hero heading "Indiana's tech community since 2008"
- `src/views/AboutView.vue` — About page story copy ("In 2008, a few Ruby developers…")
- `src/router/index.js` — About route meta description

🤖 Generated with [Claude Code](https://claude.com/claude-code)