### PR TITLE
Slack invites: email already-members, ignore deactivated/banned accounts

### DIFF
--- a/pb/hooks/slack.pb.js
+++ b/pb/hooks/slack.pb.js
@@ -337,46 +337,67 @@ onRecordAfterCreateSuccess((e) => {
     e.next()
 }, "slack_invites")
 
-// Manual approval. This runs BEFORE the update is committed: when a board member
-// flips a row to "approved" we attempt the Slack invite first, and only let the
-// status change persist (calling e.next()) if the invite actually went out. If
-// Slack fails — not configured, HTTP error, or the email is already invited / in
-// the workspace — we throw, which aborts the transaction: the row stays
-// "pending" and the admin UI shows the specific reason. This is deliberately the
-// only place a hand-approval turns into an invite (the after-create hook above
-// handles auto-approval), so an approval can never be recorded without a
-// successful send.
-onRecordUpdate((e) => {
-    const util = require(`${__hooks}/slack_util.js`)
-    const was = e.record.original().getString("status")
-    const now = e.record.getString("status")
-    if (was !== "approved" && now === "approved" && !e.record.getString("invited_at")) {
-        const { ok, outcome } = util.slackInviteOutcome(e.record.getString("email"))
-        if (!ok) {
-            // Abort before e.next(): nothing is written, so status stays "pending".
-            throw new BadRequestError(util.inviteErrorMessage(outcome))
-        }
-        e.record.set("invited_at", new Date().toISOString())
-        e.record.set("error", "")
-    }
-    e.next()
-}, "slack_invites")
-
-// Board decision → Slack webhook ping recording WHO approved/rejected. This runs
-// on the API update request (not the model hook above) because only the request
-// event carries the acting admin as e.auth. We fire only after e.next() commits
-// the update: a manual approval whose Slack invite fails makes the model hook
-// throw, e.next() rejects, and no misleading "approved" ping goes out. The ping
-// itself is best-effort and wrapped so it can never turn a committed update into
-// an error response.
+// Manual approve/reject, handled on the API update request so we have both the
+// gate (attempt the Slack invite BEFORE committing) and the acting admin
+// (e.auth, which only the request event carries). When a board member flips a
+// row to "approved" we resolve the Slack side first and only let the status
+// change persist (e.next()) once we know what happened, so an approval is never
+// recorded without the invite being resolved:
+//
+//   • sent            → mark invited_at, commit, ping the board "approved".
+//   • already_in_team → the applicant is already an active member, so there's no
+//                       invite to send. We still let the approval stand (clears
+//                       the queue) and, after commit, email them that their
+//                       account exists + how to reset a forgotten password, and
+//                       ping the board that no new invite went out.
+//   • user_disabled   → a deactivated account means the member was removed/
+//                       banned. We must NOT reactivate them and must NOT email
+//                       them: throw so the approval is aborted (row stays
+//                       pending) and the board sees why, then they can reject it.
+//   • any other error → throw as well, surfacing the reason; row stays pending.
+//
+// Rejections skip the invite entirely and just ping the board. Every ping and
+// the applicant email are best-effort and wrapped so they can't turn a committed
+// update into an error response.
 onRecordUpdateRequest((e) => {
     const util = require(`${__hooks}/slack_util.js`)
     const was = e.record.original().getString("status")
-    e.next()
     const now = e.record.getString("status")
+
+    // Delivery outcome for the post-commit board ping; only set on a fresh
+    // pending→approved transition.
+    let deliveryKind = null
+    if (was !== "approved" && now === "approved" && !e.record.getString("invited_at")) {
+        const { ok, outcome } = util.slackInviteOutcome(e.record.getString("email"))
+        if (ok) {
+            e.record.set("invited_at", new Date().toISOString())
+            e.record.set("error", "")
+            deliveryKind = "invited"
+        } else if (outcome === "already_in_team") {
+            // Already a member — nothing to send, but the approval still resolves
+            // the request. Mark it handled; the "you're already in" email goes
+            // out below, only after the commit succeeds.
+            e.record.set("invited_at", new Date().toISOString())
+            e.record.set("error", "")
+            deliveryKind = "already_member"
+        } else {
+            // user_disabled (banned) and every other non-deliverable outcome abort
+            // the approval before e.next(): nothing is written, status stays
+            // "pending", and the board sees the specific reason. A banned account
+            // is deliberately left here — never reactivated, never emailed.
+            throw new BadRequestError(util.inviteErrorMessage(outcome))
+        }
+    }
+
+    e.next()
+
+    // Post-commit, best-effort side effects (the update is already durable).
+    if (deliveryKind === "already_member") {
+        util.notifyAlreadyMember(e.record)
+    }
     if (was !== now && (now === "approved" || now === "rejected")) {
         try {
-            util.notifyInviteDecision(e.record, now, e.auth)
+            util.notifyInviteDecision(e.record, now, e.auth, deliveryKind)
         } catch (err) {
             console.error("[slack] decision webhook failed: " + err)
         }

--- a/pb/hooks/slack_util.js
+++ b/pb/hooks/slack_util.js
@@ -291,12 +291,15 @@ const captchaSignalLabel = (signals) => {
 // Returns { ok, outcome }:
 //   { ok: true,  outcome: "sent" }
 //   { ok: false, outcome: "not_configured" | "http_<status>" | "already_in_team"
-//                       | "already_invited" | "<slack error>" | "unknown_error" }
+//                       | "already_invited" | "user_disabled" | "<slack error>"
+//                       | "unknown_error" }
 //
-// NOTE: `already_invited` / `already_in_team` are treated as FAILURES. An
-// approval that lands on someone already in the workspace (or already invited)
-// doesn't deliver a usable new invite, so it should surface to the reviewer
-// rather than silently look like success.
+// NOTE: every non-"sent" outcome is `ok: false` because no NEW invite was
+// delivered — the CALLER decides what each one means. In particular
+// `already_in_team` (an existing active member) and `user_disabled` (a
+// deactivated, i.e. removed/banned, account) are not real failures so much as
+// "nothing to send"; the manual-approval path in slack.pb.js special-cases them
+// (email the member vs. ignore the ban) instead of treating them as errors.
 function slackInviteOutcome(email) {
     const token = $os.getenv("SLACK_API_TOKEN")
     const org = $os.getenv("SLACK_SUBDOMAIN")
@@ -341,11 +344,69 @@ function inviteErrorMessage(outcome) {
             return "That email is already a member of the Slack workspace — no invite was sent."
         case "already_invited":
             return "That email has already been invited to Slack — no new invite was sent."
+        case "user_disabled":
+            return "That account is deactivated in Slack (the member was removed/banned), so it was not reinvited and no email was sent."
     }
     if (outcome.indexOf("http_") === 0) {
         return "Slack returned an HTTP error (" + outcome.slice(5) + "); the invite was not sent."
     }
     return "Slack rejected the invite (" + outcome + "); the invite was not sent."
+}
+
+// Emails an applicant whose invite bounced with `already_in_team` — they already
+// have an active account on the workspace, so there's no invite to send. Rather
+// than a dead-end, we tell them the account exists, how to sign in, how to reset
+// a forgotten password, and that admin@indyhackers.org is there if they get
+// stuck. Best-effort: wrapped so a mail failure can never turn the approval it
+// accompanies into an error. Returns true when the mail was handed to the
+// client, false otherwise. NOTE: only call this for `already_in_team` — a
+// `user_disabled` (deactivated/banned) account must NOT be emailed.
+function notifyAlreadyMember(record) {
+    try {
+        const email = record.getString("email")
+        if (!email) return false
+        const firstName = record.getString("first_name")
+        const greeting = firstName ? "Hi " + firstName + "," : "Hi,"
+
+        const org = $os.getenv("SLACK_SUBDOMAIN") || ""
+        const signInUrl = org ? "https://" + org + ".slack.com" : "https://slack.com/signin"
+        // Slack's per-workspace forgot-password page pre-fills the workspace so
+        // the reset lands on the right account; fall back to the generic page.
+        const resetUrl = org ? "https://" + org + ".slack.com/forgot" : "https://slack.com/forgot"
+        const adminEmail = "admin@indyhackers.org"
+
+        const esc = (v) =>
+            String(v == null ? "" : v)
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;")
+                .replace(/'/g, "&#39;")
+
+        const html =
+            "<p>" + esc(greeting) + "</p>" +
+            "<p>Thanks for your interest in the IndyHackers Slack! Good news — you already have an " +
+            "account on our workspace, so there's nothing more you need to do to join. You're already in.</p>" +
+            '<p>You can sign in any time at <a href="' + esc(signInUrl) + '">' + esc(signInUrl) + "</a>.</p>" +
+            '<p>Forgot your password? You can reset it here: <a href="' + esc(resetUrl) + '">' + esc(resetUrl) + "</a>.</p>" +
+            '<p>If you run into any trouble, just email us at <a href="mailto:' + esc(adminEmail) + '">' +
+            esc(adminEmail) + "</a> and we'll help you get back in.</p>" +
+            "<p>See you in Slack!<br>— The IndyHackers team</p>"
+
+        const settings = $app.settings()
+        const message = new MailerMessage({
+            from: { address: settings.meta.senderAddress, name: settings.meta.senderName },
+            to: [{ address: email }],
+            subject: "You're already a member of the IndyHackers Slack",
+            html: html,
+        })
+        $app.newMailClient().send(message)
+        console.log("[slack] already-member email sent to " + email)
+        return true
+    } catch (err) {
+        console.error("[slack] already-member email failed: " + err)
+        return false
+    }
 }
 
 // True when `ip` is a routable public address worth sending to the ISP lookup —
@@ -668,19 +729,33 @@ function adminLabel(authRecord) {
 
 // Posts a Slack ping when a board member approves or rejects an invite request,
 // naming the acting admin. `decision` is "approved" or "rejected"; `authRecord`
-// is the request's e.auth. Best-effort (delegates to postSlackWebhook).
-function notifyInviteDecision(record, decision, authRecord) {
+// is the request's e.auth. `deliveryKind` (only meaningful when approved) is
+// "invited" for a normal fresh invite or "already_member" when the applicant was
+// already an active member — in that case no invite was sent and they were
+// emailed how to sign in / reset their password instead, which the ping spells
+// out so the board isn't left thinking a new invite went out. Best-effort
+// (delegates to postSlackWebhook).
+function notifyInviteDecision(record, decision, authRecord, deliveryKind) {
     const approved = decision === "approved"
+    const alreadyMember = approved && deliveryKind === "already_member"
     const email = record.getString("email")
     const name = [record.getString("first_name"), record.getString("last_name")]
         .filter(Boolean).join(" ") || "(no name given)"
 
+    let header
+    if (!approved) header = ":x: *Slack invite rejected*"
+    else if (alreadyMember) header = ":information_source: *Already a Slack member — no new invite sent*"
+    else header = ":white_check_mark: *Slack invite approved*"
+
     const lines = [
-        approved ? ":white_check_mark: *Slack invite approved*" : ":x: *Slack invite rejected*",
+        header,
         "*Name:* " + slackEscape(name),
         "*Email:* " + slackEscape(email),
         "*" + (approved ? "Approved" : "Rejected") + " by:* " + slackEscape(adminLabel(authRecord)),
     ]
+    if (alreadyMember) {
+        lines.push("*Result:* They already had an account, so no invite was sent — emailed them how to sign in and reset their Slack password.")
+    }
 
     postSlackWebhook(lines.join("\n"))
 }
@@ -696,6 +771,7 @@ module.exports = {
     ispLabel,
     slackInviteOutcome,
     inviteErrorMessage,
+    notifyAlreadyMember,
     notifyBoard,
     slackEscape,
     postSlackWebhook,


### PR DESCRIPTION
## Why

Approving a Slack invite request on `/admin/slack-invites` silently did nothing when the applicant was **already in the Slack workspace**: Slack returns `already_in_team`, the approve hook treated any non-send as a hard failure and aborted the update, so the row never left the pending queue (the reason was only shown in a small line at the bottom of the page, easy to miss). This is what prompted the "click Approve, nothing happens" report for `owentrudt@gmail.com`.

## What changed

Manual approval (`pb/hooks/slack.pb.js`, `pb/hooks/slack_util.js`) now handles the two "nothing to send" Slack outcomes explicitly:

- **`already_in_team`** (already an active member) → let the approval stand so the row clears the queue, and **email the applicant** that their account already exists, with sign-in + password-reset links and `admin@indyhackers.org` for help.
- **`user_disabled`** (deactivated = removed/banned) → do **not** reactivate and do **not** email them; abort the approval with the reason surfaced so the board can reject it.
- **Moderator-channel decision ping** now spells out when no new invite was sent because the person was already a member (and that they were emailed password-reset info).

The manual-approval invite gate is consolidated into `onRecordUpdateRequest` so a single handler has both the pre-commit gate and the acting admin (`e.auth`).

## Verification

Logic exercised by loading the hook module as CommonJS with stubbed PocketBase globals: the three notification variants, the `user_disabled` admin message, and the applicant email all render correctly. The `user_disabled` error code was confirmed against Slack's community `users.admin.invite` docs — worth a live check against a real deactivated account when convenient, since full runtime verification needs a PocketBase instance with Slack + mailer creds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)